### PR TITLE
Add timestamp information to groupbyquery results

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -49,7 +49,7 @@ lazy val root = (project in file("."))
   .settings(commonSettings)
   .settings(
     name := "scruid",
-    version := "0.0.5",
+    version := "0.0.6",
     libraryDependencies ++= Seq(
       "com.typesafe" % "config" % "1.3.1",
 

--- a/src/test/scala/ing/wbaa/druid/DruidTest.scala
+++ b/src/test/scala/ing/wbaa/druid/DruidTest.scala
@@ -17,7 +17,7 @@
 package ing.wbaa.druid
 
 import ing.wbaa.druid.definitions._
-import ing.wbaa.druid.query.{GroupByQuery, TimeSeriesQuery, TopNQuery}
+import ing.wbaa.druid.query.{GroupByQuery, GroupByQueryResult, TimeSeriesQuery, TopNQuery}
 import org.scalatest.{FunSuiteLike, Inside, OptionValues}
 
 case class TimeseriesCount(count: Int)
@@ -114,7 +114,7 @@ class DruidTest extends FunSuiteLike with Inside with OptionValues {
     //  }]
 
     // The number of entries in the data set
-    assert(result.map(_.count).sum == totalNumberOfEntries)
+    assert(result.map(_.event.count).sum == totalNumberOfEntries)
   }
 
 


### PR DESCRIPTION
When doing a granularity other then all the timestamp information was missing from the results.

Added the GroupByQueryResult in the same way the TimeSeriesResult was used and update the version number to 0.0.6