### PR TITLE
Move to Akka http client

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -34,7 +34,8 @@ lazy val commonSettings: Seq[Setting[_]] = Seq(
       s"git@github.com:${bintrayOrganization.value.get}/${name.value}.git"
     )
   ),
-  crossScalaVersions in ThisBuild := Seq("2.10.6", "2.11.8", "2.12.2"),
+  crossScalaVersions in ThisBuild := Seq("2.11.8", "2.12.3"),
+  scalaVersion in ThisBuild := "2.12.3",
   scalacOptions ++= Seq(Opts.compile.deprecation, "-Xlint", "-feature"),
   scalacOptions ++= PartialFunction.condOpt(CrossVersion.partialVersion(scalaVersion.value)) {
     case Some((2, v)) if v >= 11 => unusedWarnings
@@ -49,14 +50,14 @@ lazy val root = (project in file("."))
   .settings(commonSettings)
   .settings(
     name := "scruid",
-    version := "0.0.7",
+    version := "0.0.8",
     libraryDependencies ++= Seq(
       "com.typesafe" % "config" % "1.3.1",
 
       "org.json4s" %% "json4s-jackson" % "3.5.2",
       "org.json4s" %% "json4s-ext" % "3.5.2",
 
-      "org.scalaj" %% "scalaj-http" % "2.3.0",
+      "com.typesafe.akka" %% "akka-http" % "10.0.9",
 
       "ch.qos.logback" % "logback-classic" % "1.1.3",
 

--- a/circle.yml
+++ b/circle.yml
@@ -5,7 +5,7 @@ machine:
   java:
     version: oraclejdk8
   environment:
-    SCALA_VERSION: 2.12.2
+    SCALA_VERSION: 2.12.3
     SCALA_BINARY_VERSION: 2.12
 
 dependencies:

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -187,7 +187,7 @@ This file is divided into 3 sections:
     ]]></customMessage>
     </check>
 
-    <check customId="awaitresult" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <check customId="awaitresult" level="error" class="org.scalastyle.file.RegexChecker" enabled="false">
         <parameters>
             <parameter name="regex">Await\.result</parameter>
         </parameters>

--- a/src/main/scala/ing/wbaa/druid/definitions/Filter.scala
+++ b/src/main/scala/ing/wbaa/druid/definitions/Filter.scala
@@ -17,7 +17,7 @@
 
 package ing.wbaa.druid.definitions
 
-trait Filter {
+sealed trait Filter {
   val kind: String
 }
 


### PR DESCRIPTION
Instead of using the scalaj-http client, we want to have something more sophisticated that supports futures for handling async calls