### PR TITLE
Implement (single field) aggregation types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 target/
 
 .idea/
+
+.ensime*

--- a/README.md
+++ b/README.md
@@ -23,8 +23,7 @@ TopNQuery[TopCountry](
   threshold = 5,
   metric = "count",
   aggregations = List(
-    Aggregation(
-      kind = "count",
+    CountAggregation(
       name = "count",
       fieldName = "count"
     )
@@ -41,8 +40,7 @@ case class GroupByIsAnonymous(isAnonymous: Boolean, count: Int)
 
 val result = GroupByQuery[GroupByIsAnonymous](
   aggregations = List(
-    Aggregation(
-      kind = "count",
+    CountAggregation(
       name = "count",
       fieldName = "count"
     )
@@ -61,8 +59,7 @@ case class TimeseriesCount(count: Int)
 
 val result = TimeSeriesQuery[TimeseriesCount](
   aggregations = List(
-    Aggregation(
-      kind = "count",
+    CountAggregation(
       name = "count",
       fieldName = "count"
     )
@@ -72,11 +69,11 @@ val result = TimeSeriesQuery[TimeseriesCount](
 ).execute
 ```
 
-This will return a `List[TimeSeriesResult[TimeseriesCount]]`. Where the `TimeSeriesResult` contains the timestamp of the interval in joda time, and the `TimeseriesCount` class contains the actual result of the query as defined in the aggregation. 
+This will return a `List[TimeSeriesResult[TimeseriesCount]]`. Where the `TimeSeriesResult` contains the timestamp of the interval in joda time, and the `TimeseriesCount` class contains the actual result of the query as defined in the aggregation.
 
 ## Configuration
 
-The configuration is done by [Typesafe config](https://github.com/typesafehub/config). The configuration can be overriden by using environment variables, e.g. `DRUID_URL` and `DRUID_DATASOURCE`. Or by placing an application.conf in your own project and this will override the reference.conf of the scruid library. 
+The configuration is done by [Typesafe config](https://github.com/typesafehub/config). The configuration can be overriden by using environment variables, e.g. `DRUID_URL` and `DRUID_DATASOURCE`. Or by placing an application.conf in your own project and this will override the reference.conf of the scruid library.
 
 ```
 druid = {

--- a/src/main/scala/ing/wbaa/druid/common/DruidClient.scala
+++ b/src/main/scala/ing/wbaa/druid/common/DruidClient.scala
@@ -41,13 +41,10 @@ object DruidClient {
   import scala.concurrent.ExecutionContext.Implicits.global
 
   implicit val formats: Formats = Serialization.formats(NoTypeHints).preservingEmptyValues +
-    FieldSerializer[Aggregation](// Some renaming because type is a reserved keyword in Scala
-      renameTo("kind", "type"),
-      renameFrom("type", "kind")
-    ) + FieldSerializer[Filter](
+    FieldSerializer[Aggregation]() + FieldSerializer[Filter](
     renameTo("kind", "type"),
     renameFrom("type", "kind")
-  ) + FieldSerializer[DruidQuery[_]]()
+  ) + FieldSerializer[DruidQuery[_]]() + json.AggregationTypeSerializer
 
   /**
     * Execute the query by performing a POST request to the Druid broker

--- a/src/main/scala/ing/wbaa/druid/common/json/AggregationTypeSerializer.scala
+++ b/src/main/scala/ing/wbaa/druid/common/json/AggregationTypeSerializer.scala
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ing.wbaa.druid.common.json
+
+import org.json4s.MappingException
+import ing.wbaa.druid.definitions.AggregationType
+import org.json4s.CustomSerializer
+import org.json4s.JsonAST.JString
+
+case object AggregationTypeSerializer extends CustomSerializer[AggregationType](
+  format => ( {
+    case JString(x) =>
+      AggregationType.values.find(_.value == x).getOrElse(
+        throw new MappingException(s"$x is not a known aggregation type")
+      )
+  }, {
+    case x: AggregationType => JString(x.value)
+  }))

--- a/src/main/scala/ing/wbaa/druid/definitions/Aggregation.scala
+++ b/src/main/scala/ing/wbaa/druid/definitions/Aggregation.scala
@@ -17,6 +17,47 @@
 
 package ing.wbaa.druid.definitions
 
-case class Aggregation(kind: String,
-                       name: String,
-                       fieldName: String)
+sealed trait AggregationType {
+  private def decapitalize(input: String) = {
+    val chars = input.toCharArray
+    chars(0) = Character.toLowerCase(chars(0))
+    chars.mkString
+  }
+  lazy val value: String = decapitalize(this.getClass.getSimpleName.replace("$", ""))
+}
+object AggregationType {
+  case object Count extends AggregationType
+  case object LongSum extends AggregationType
+  case object DoubleSum extends AggregationType
+  case object DoubleMax extends AggregationType
+  case object DoubleMin extends AggregationType
+  case object LongMin extends AggregationType
+  case object LongMax extends AggregationType
+  case object DoubleFirst extends AggregationType
+  case object DoubleLast extends AggregationType
+  case object LongFirst extends AggregationType
+  case object LongLast extends AggregationType
+
+  val values = Set(Count, LongSum, DoubleSum, DoubleMax, DoubleMin, LongMin, LongMax, DoubleFirst, DoubleLast, LongFirst, LongLast)
+}
+
+trait Aggregation {
+  val `type`: AggregationType
+}
+
+trait SingleFieldAggregation extends Aggregation {
+  val name: String
+  val fieldName: String
+}
+
+case class CountAggregation(name: String, fieldName: String) extends SingleFieldAggregation{ val `type` = AggregationType.Count }
+case class LongSumAggregation(name: String, fieldName: String) extends SingleFieldAggregation{ val `type` = AggregationType.LongSum }
+case class DoubleSumAggregation(name: String, fieldName: String) extends SingleFieldAggregation{ val `type` = AggregationType.DoubleSum }
+case class DoubleMaxAggregation(name: String, fieldName: String) extends SingleFieldAggregation{ val `type` = AggregationType.DoubleMax }
+case class DoubleMinAggregation(name: String, fieldName: String) extends SingleFieldAggregation{ val `type` = AggregationType.DoubleMin }
+case class LongMinAggregation(name: String, fieldName: String) extends SingleFieldAggregation{ val `type` = AggregationType.LongMin }
+case class LongMaxAggregation(name: String, fieldName: String) extends SingleFieldAggregation{ val `type` = AggregationType.LongMax }
+case class DoubleFirstAggregation(name: String, fieldName: String) extends SingleFieldAggregation{ val `type` = AggregationType.DoubleFirst }
+case class DoubleLastAggregation(name: String, fieldName: String) extends SingleFieldAggregation{ val `type` = AggregationType.DoubleLast }
+case class LongFirstAggregation(name: String, fieldName: String) extends SingleFieldAggregation{ val `type` = AggregationType.LongFirst }
+case class LongLastAggregation(name: String, fieldName: String) extends SingleFieldAggregation{ val `type` = AggregationType.LongLast }

--- a/src/test/scala/ing/wbaa/druid/DruidTest.scala
+++ b/src/test/scala/ing/wbaa/druid/DruidTest.scala
@@ -17,7 +17,7 @@
 package ing.wbaa.druid
 
 import ing.wbaa.druid.definitions.FilterOperators._
-import ing.wbaa.druid.definitions.{Aggregation, _}
+import ing.wbaa.druid.definitions._
 import ing.wbaa.druid.query.{GroupByQuery, TimeSeriesQuery, TopNQuery}
 import org.scalatest.{FunSuiteLike, Inside, OptionValues}
 
@@ -54,8 +54,7 @@ class DruidTest extends FunSuiteLike with Inside with OptionValues {
 
     val resultFuture = TimeSeriesQuery[TimeseriesCount](
       aggregations = List(
-        Aggregation(
-          kind = "count",
+        CountAggregation(
           name = "count",
           fieldName = "count"
         )
@@ -95,8 +94,7 @@ class DruidTest extends FunSuiteLike with Inside with OptionValues {
 
     val resultFuture = GroupByQuery[GroupByIsAnonymous](
       aggregations = List(
-        Aggregation(
-          kind = "count",
+        CountAggregation(
           name = "count",
           fieldName = "count"
         )
@@ -160,8 +158,7 @@ class DruidTest extends FunSuiteLike with Inside with OptionValues {
       threshold = threshold,
       metric = "count",
       aggregations = List(
-        Aggregation(
-          kind = "count",
+        CountAggregation(
           name = "count",
           fieldName = "count"
         )
@@ -252,8 +249,7 @@ class DruidTest extends FunSuiteLike with Inside with OptionValues {
       threshold = 5,
       metric = "count",
       aggregations = List(
-        Aggregation(
-          kind = "count",
+        CountAggregation(
           name = "count",
           fieldName = "count"
         )

--- a/src/test/scala/ing/wbaa/druid/common/json/AggregationTypeSerializerSpec.scala
+++ b/src/test/scala/ing/wbaa/druid/common/json/AggregationTypeSerializerSpec.scala
@@ -1,0 +1,29 @@
+package ing.wbaa.druid.common.json
+
+import org.scalatest._
+import org.json4s._
+import org.json4s.jackson.Serialization
+import org.json4s.jackson.Serialization.{read, write}
+import ing.wbaa.druid.definitions.AggregationType
+
+class AggregationTypeSerializerSpec extends WordSpec with Matchers {
+  implicit val formats = Serialization.formats(NoTypeHints) + AggregationTypeSerializer
+  "AggregationTypeSerializer" should {
+    "serialize to json" in {
+      val serialized: String = write(AggregationType.LongSum)
+      serialized shouldBe """"longSum""""
+    }
+
+    "deserialize to a type" in {
+      val deserialized = read[AggregationType](""""doubleMax"""")
+      deserialized shouldBe AggregationType.DoubleMax
+    }
+
+    "throw an exception when the aggregation type is not known" in {
+      val caught = intercept[MappingException] {
+        read[AggregationType]("""""fakeType"""")
+      }
+      caught.getMessage should include("not a known aggregation type")
+    }
+  }
+}


### PR DESCRIPTION
I think we can benefit from introducing more types reflecting the Druid API. 

This first PR implements the different types of Aggregations that are available instead of excepting any `String`.

I restructured the `Aggregation` setup a bit, so that we can more easily add other allowed but more complex types in the future.