### PR TITLE
Correct count aggregation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -50,7 +50,7 @@ lazy val root = (project in file("."))
   .settings(commonSettings)
   .settings(
     name := "scruid",
-    version := "0.1.0.0",
+    version := "0.1.0.1",
     libraryDependencies ++= Seq(
       "com.typesafe" % "config" % "1.3.1",
 

--- a/src/main/scala/ing/wbaa/druid/definitions/Aggregation.scala
+++ b/src/main/scala/ing/wbaa/druid/definitions/Aggregation.scala
@@ -43,14 +43,14 @@ object AggregationType {
 
 trait Aggregation {
   val `type`: AggregationType
+  val name: String
 }
 
 trait SingleFieldAggregation extends Aggregation {
-  val name: String
   val fieldName: String
 }
 
-case class CountAggregation(name: String, fieldName: String) extends SingleFieldAggregation{ val `type` = AggregationType.Count }
+case class CountAggregation(name: String) extends Aggregation{ val `type` = AggregationType.Count }
 case class LongSumAggregation(name: String, fieldName: String) extends SingleFieldAggregation{ val `type` = AggregationType.LongSum }
 case class DoubleSumAggregation(name: String, fieldName: String) extends SingleFieldAggregation{ val `type` = AggregationType.DoubleSum }
 case class DoubleMaxAggregation(name: String, fieldName: String) extends SingleFieldAggregation{ val `type` = AggregationType.DoubleMax }

--- a/src/test/scala/ing/wbaa/druid/DruidTest.scala
+++ b/src/test/scala/ing/wbaa/druid/DruidTest.scala
@@ -54,10 +54,7 @@ class DruidTest extends FunSuiteLike with Inside with OptionValues {
 
     val resultFuture = TimeSeriesQuery[TimeseriesCount](
       aggregations = List(
-        CountAggregation(
-          name = "count",
-          fieldName = "count"
-        )
+        CountAggregation(name = "count")
       ),
       granularity = "hour",
       intervals = List("2011-06-01/2017-06-01")
@@ -94,10 +91,7 @@ class DruidTest extends FunSuiteLike with Inside with OptionValues {
 
     val resultFuture = GroupByQuery[GroupByIsAnonymous](
       aggregations = List(
-        CountAggregation(
-          name = "count",
-          fieldName = "count"
-        )
+        CountAggregation(name = "count")
       ),
       dimensions = List(Dimension(dimension = "isAnonymous")),
       intervals = List("2011-06-01/2017-06-01")
@@ -158,10 +152,7 @@ class DruidTest extends FunSuiteLike with Inside with OptionValues {
       threshold = threshold,
       metric = "count",
       aggregations = List(
-        CountAggregation(
-          name = "count",
-          fieldName = "count"
-        )
+        CountAggregation(name = "count")
       ),
       intervals = List("2011-06-01/2017-06-01")
     ).execute
@@ -249,10 +240,7 @@ class DruidTest extends FunSuiteLike with Inside with OptionValues {
       threshold = 5,
       metric = "count",
       aggregations = List(
-        CountAggregation(
-          name = "count",
-          fieldName = "count"
-        )
+        CountAggregation(name = "count")
       ),
       intervals = List("2011-06-01/2017-06-01")
     ).execute


### PR DESCRIPTION
On a closer look, it turns out that the `CountAggregation` does not really depends on a `fieldName` to be present, because the count aggregation "computes the count of Druid rows that match the filters."