### PR TITLE
Add configurable Druid response parsing timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,8 +93,7 @@ druid = {
   datasource = "wikiticker"
   datasource = ${?DRUID_DATASOURCE}
 
-  connectionTimeout = 10000
-  readTimeout = 30000
+  response-parsing-timeout = 5 seconds
 }
 ```
 

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -11,6 +11,5 @@ druid = {
   datasource = "wikiticker"
   datasource = ${?DRUID_DATASOURCE}
 
-  connectionTimeout = 10000
-  readTimeout = 30000
+  response-parsing-timeout = 5 seconds
 }

--- a/src/main/scala/ing/wbaa/druid/DruidConfig.scala
+++ b/src/main/scala/ing/wbaa/druid/DruidConfig.scala
@@ -17,19 +17,24 @@ package ing.wbaa.druid
 
 import com.typesafe.config.ConfigFactory
 
+import scala.concurrent.duration.FiniteDuration
+import scala.language.implicitConversions
+
 /*
- * Domino API Config Immutable
+ * Druid API Config Immutable
  */
 object DruidConfig {
+  implicit def asFiniteDuration(d: java.time.Duration): FiniteDuration =
+    scala.concurrent.duration.Duration.fromNanos(d.toNanos)
+
   private val config      = ConfigFactory.load()
   private val druidConfig = config.getConfig("druid")
 
   /** Druid url */
-  val host: String           = druidConfig.getString("host")
-  val port: Int              = druidConfig.getInt("port")
-  val secure: Boolean        = druidConfig.getBoolean("secure")
-  val url: String            = druidConfig.getString("url")
-  val datasource: String     = druidConfig.getString("datasource")
-  val readTimeout: Int       = druidConfig.getInt("readTimeout")
-  val connectionTimeout: Int = druidConfig.getInt("connectionTimeout")
+  val host: String                           = druidConfig.getString("host")
+  val port: Int                              = druidConfig.getInt("port")
+  val secure: Boolean                        = druidConfig.getBoolean("secure")
+  val url: String                            = druidConfig.getString("url")
+  val datasource: String                     = druidConfig.getString("datasource")
+  val responseParsingTimeout: FiniteDuration = druidConfig.getDuration("response-parsing-timeout")
 }


### PR DESCRIPTION
As found in #16 the Druid response entity parsing has a hardcoded timeout set to 5 seconds. The `reference.conf` and `README.md` had a few redundant config properties which I replaced by a configuration properly specifically for defining the request entity parsing timeout.