### PR TITLE
Extraction dimension and functions

### DIFF
--- a/src/main/scala/ing/wbaa/druid/definitions/ExtractionFn.scala
+++ b/src/main/scala/ing/wbaa/druid/definitions/ExtractionFn.scala
@@ -1,0 +1,156 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ing.wbaa.druid
+package definitions
+
+import ca.mrvisser.sealerate
+import io.circe.Encoder
+import io.circe.generic.auto._
+import io.circe.syntax._
+
+sealed trait ExtractionFnType extends Enum with CamelCaseEnumStringEncoder
+object ExtractionFnType extends EnumCodec[ExtractionFnType] {
+  case object Regex            extends ExtractionFnType
+  case object Partial          extends ExtractionFnType
+  case object SearchQuery      extends ExtractionFnType // not implemented yet
+  case object Strlen           extends ExtractionFnType
+  case object Substring        extends ExtractionFnType
+  case object TimeFormat       extends ExtractionFnType
+  case object Time             extends ExtractionFnType
+  case object Javascript       extends ExtractionFnType
+  case object Lookup           extends ExtractionFnType // not implemented yet
+  case object RegisteredLookup extends ExtractionFnType // not implemented yet
+  case object Cascade          extends ExtractionFnType
+  case object StringFormat     extends ExtractionFnType
+  case object Upper            extends ExtractionFnType
+  case object Lower            extends ExtractionFnType
+  case object Bucket           extends ExtractionFnType
+
+  override val values: Set[ExtractionFnType] = sealerate.values[ExtractionFnType]
+}
+
+sealed trait ExtractionFn {
+  val `type`: ExtractionFnType
+}
+
+object ExtractionFn {
+  implicit val encoder: Encoder[ExtractionFn] = new Encoder[ExtractionFn] {
+    override def apply(extFn: ExtractionFn) =
+      (extFn match {
+        case x: RegexExtractionFn        => x.asJsonObject
+        case x: PartialExtractionFn      => x.asJsonObject
+        case x: SubstringExtractionFn    => x.asJsonObject
+        case StrlenExtractionFn          => StrlenExtractionFn.asJsonObject
+        case x: TimeFormatExtractionFn   => x.asJsonObject
+        case x: TimeParsingExtractionFn  => x.asJsonObject
+        case x: JavascriptExtractionFn   => x.asJsonObject
+        case x: CascadeExtractionFn      => x.asJsonObject
+        case x: StringFormatExtractionFn => x.asJsonObject
+        case x: UpperExtractionFn        => x.asJsonObject
+        case x: LowerExtractionFn        => x.asJsonObject
+        case x: BucketExtractionFn       => x.asJsonObject
+      }).add("type", extFn.`type`.asJson).asJson
+  }
+}
+
+case class RegexExtractionFn(
+    expr: String,
+    index: Option[Int] = Some(1),
+    replaceMissingValue: Option[Boolean] = Some(false),
+    replaceMissingValueWith: Option[String] = None
+) extends ExtractionFn {
+  override val `type` = ExtractionFnType.Regex
+}
+
+case class PartialExtractionFn(
+    expr: String
+) extends ExtractionFn {
+  override val `type` = ExtractionFnType.Partial
+}
+
+case class SubstringExtractionFn(
+    index: Int,
+    length: Option[Int] = None
+) extends ExtractionFn {
+  override val `type` = ExtractionFnType.Substring
+}
+
+case object StrlenExtractionFn extends ExtractionFn {
+  override val `type` = ExtractionFnType.Strlen
+}
+
+case class TimeFormatExtractionFn(
+    format: Option[String] = None,
+    timeZone: Option[String] = Some("utc"),
+    locale: Option[String] = None,
+    granularity: Option[Granularity] = Some(GranularityType.None),
+    asMillis: Option[Boolean] = Some(false)
+) extends ExtractionFn {
+  override val `type` = ExtractionFnType.TimeFormat
+}
+
+case class TimeParsingExtractionFn(
+    timeFormat: String,
+    resultFormat: String
+) extends ExtractionFn {
+  override val `type` = ExtractionFnType.Time
+}
+
+case class JavascriptExtractionFn(
+    function: String,
+    injective: Option[Boolean] = Some(false)
+) extends ExtractionFn {
+  override val `type` = ExtractionFnType.Javascript
+}
+
+case class CascadeExtractionFn(
+    extractionFns: Seq[ExtractionFn]
+) extends ExtractionFn {
+  override val `type` = ExtractionFnType.Cascade
+}
+
+sealed trait NullHandling extends Enum with CamelCaseEnumStringEncoder
+object NullHandling extends EnumCodec[NullHandling] {
+  case object NullString  extends NullHandling
+  case object EmptyString extends NullHandling
+  case object ReturnNull  extends NullHandling
+
+  override val values: Set[NullHandling] = sealerate.values[NullHandling]
+}
+
+case class StringFormatExtractionFn(
+    format: String,
+    nullHandling: Option[NullHandling] = Some(NullHandling.NullString)
+) extends ExtractionFn {
+  override val `type` = ExtractionFnType.StringFormat
+}
+
+case class UpperExtractionFn(locale: Option[String] = None) extends ExtractionFn {
+  val `type` = ExtractionFnType.Upper
+}
+
+case class LowerExtractionFn(locale: Option[String] = None) extends ExtractionFn {
+  val `type` = ExtractionFnType.Lower
+}
+
+case class BucketExtractionFn(
+    size: Option[Int] = Some(1),
+    offset: Option[Int] = Some(0)
+) extends ExtractionFn {
+  val `type` = ExtractionFnType.Bucket
+}

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -1,0 +1,11 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>

--- a/src/test/scala/ing/wbaa/druid/definitions/ExtractionFnSpec.scala
+++ b/src/test/scala/ing/wbaa/druid/definitions/ExtractionFnSpec.scala
@@ -1,0 +1,438 @@
+package ing.wbaa.druid.definitions
+
+import ing.wbaa.druid.GroupByQuery
+import ing.wbaa.druid.definitions.FilterOperators._
+import io.circe.generic.auto._
+import io.circe.syntax._
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.{ Matchers, WordSpecLike }
+
+import scala.concurrent.duration._
+import scala.language.postfixOps
+
+class ExtractionFnSpec extends Matchers with WordSpecLike with ScalaFutures {
+
+  override implicit def patienceConfig: PatienceConfig = PatienceConfig(5 seconds, 50 millis)
+
+  // countyName is optional, because some extractions functions work with nulls and
+  // not every fetched item has countryName.
+  final case class GroupByCountryName(countryName: Option[String], count: Int)
+  final case class GroupByTime(time: String, count: Int)
+  final case class GroupByAddedAndCountryName(added: Int, countryName: Option[String], count: Int)
+
+  sealed trait TestContext {
+    def baseRequest(dimensions: Dimension*) = GroupByQuery(
+      aggregations = List(CountAggregation(name = "count")),
+      intervals = List("2015-09-12T21:00:00/2015-09-12T22:00:00"),
+      granularity = GranularityType.Hour,
+      dimensions = dimensions.toList,
+      filter = Some(!SelectFilter("countryName", ""))
+    )
+  }
+
+  "ExtractionFn" when {
+    "using Regex" should {
+      "be encoded properly" in {
+        val fn1: ExtractionFn = RegexExtractionFn("(\\w\\w\\w).*")
+        fn1.asJson.noSpaces shouldBe
+        """{"expr":"(\\w\\w\\w).*","index":1,"replaceMissingValue":false,"replaceMissingValueWith":null,"type":"regex"}"""
+
+        val fn2: ExtractionFn = RegexExtractionFn(".*", Some(2), Some(true), Some("foo"))
+        fn2.asJson.noSpaces shouldBe
+        """{"expr":".*","index":2,"replaceMissingValue":true,"replaceMissingValueWith":"foo","type":"regex"}"""
+      }
+
+      "return items transformed by regex" in new TestContext {
+        val request = baseRequest(
+          ExtractionDimension(
+            dimension = "countryName",
+            extractionFn = RegexExtractionFn("(\\w\\w\\w).*")
+          )
+        )
+        whenReady(request.execute()) { response =>
+          val list = response.list[GroupByCountryName].filter(_.count > 13)
+          list shouldBe List(
+            GroupByCountryName(Some("Fra"), 14),
+            GroupByCountryName(Some("Uni"), 48) // United States 36 + United Kingdom 12
+          )
+        }
+      }
+    }
+
+    "using Partial" should {
+      "be encoded propely" in {
+        val fn: ExtractionFn = PartialExtractionFn("ca$")
+        fn.asJson.noSpaces shouldBe """{"expr":"ca$","type":"partial"}"""
+      }
+
+      "return items for which regular expression matches" in new TestContext {
+        val request = baseRequest(
+          ExtractionDimension(
+            dimension = "countryName",
+            extractionFn = PartialExtractionFn("ca$")
+          )
+        )
+
+        whenReady(request.execute()) { response =>
+          val list = response.list[GroupByCountryName]
+          list shouldBe List(
+            GroupByCountryName(None, 191), // null appears after function transformation, not before. Use Having to filter such nulls out.
+            GroupByCountryName(Some("South Africa"), 1)
+          )
+        }
+      }
+    }
+
+    "using Strlen" should {
+      "be encoded propely" in {
+        val fn: ExtractionFn = StrlenExtractionFn
+        fn.asJson.noSpaces shouldBe """{"type":"strlen"}"""
+      }
+
+      "return length of items" in new TestContext {
+        val request = baseRequest(
+          ExtractionDimension(
+            dimension = "countryName",
+            extractionFn = StrlenExtractionFn
+          )
+        )
+
+        whenReady(request.execute()) { response =>
+          val list = response.list[GroupByCountryName].filter(_.count > 30)
+          list shouldBe List(
+            GroupByCountryName(Some("13"), 36),
+            GroupByCountryName(Some("6"), 64)
+          )
+        }
+      }
+    }
+
+    "using Substring" should {
+      "be encoded propely" in {
+        val fn1: ExtractionFn = SubstringExtractionFn(1)
+        fn1.asJson.noSpaces shouldBe """{"index":1,"length":null,"type":"substring"}"""
+
+        val fn2: ExtractionFn = SubstringExtractionFn(1, Some(3))
+        fn2.asJson.noSpaces shouldBe """{"index":1,"length":3,"type":"substring"}"""
+      }
+
+      "return length of items" in new TestContext {
+        val request = baseRequest(
+          ExtractionDimension(
+            dimension = "countryName",
+            extractionFn = SubstringExtractionFn(0, Some(4))
+          )
+        )
+
+        whenReady(request.execute()) { response =>
+          val list = response.list[GroupByCountryName].filter(_.count > 13)
+          list shouldBe List(
+            GroupByCountryName(Some("Fran"), 14),
+            GroupByCountryName(Some("Unit"), 48)
+          )
+        }
+      }
+    }
+
+    "using TimeFormat" should {
+      "be encoded propely" in {
+        val fn1: ExtractionFn = TimeFormatExtractionFn()
+        fn1.asJson.noSpaces shouldBe
+        """{"format":null,"timeZone":"utc","locale":null,"granularity":"none","asMillis":false,"type":"timeFormat"}"""
+
+        val fn2: ExtractionFn = TimeFormatExtractionFn(Some("HH"),
+                                                       Some("Europe/Berlin"),
+                                                       Some("en-GB"),
+                                                       Some(GranularityType.Hour),
+                                                       Some(true))
+        fn2.asJson.noSpaces shouldBe
+        """{"format":"HH","timeZone":"Europe/Berlin","locale":"en-GB","granularity":"hour","asMillis":true,"type":"timeFormat"}"""
+      }
+
+      "return extracted time" in new TestContext {
+        def request(extFn: ExtractionFn) =
+          baseRequest(
+            ExtractionDimension(
+              dimension = "__time",
+              outputName = Some("time"),
+              extractionFn = extFn
+            )
+          )
+
+        val fn1 = TimeFormatExtractionFn()
+        whenReady(request(fn1).execute()) { response =>
+          response.list[GroupByTime].size shouldBe 192
+        }
+
+        val fn2 = TimeFormatExtractionFn(
+          granularity = Some(GranularityType.ThirtyMinute),
+          // need to set zone to None, when asMillis = true. With default "utc" it will also require to provide time format, but we want just millis
+          timeZone = None,
+          asMillis = Some(true)
+        )
+        whenReady(request(fn2).execute()) { response =>
+          val list = response.list[GroupByTime]
+          list shouldBe List(
+            GroupByTime("1442091600000", 89),
+            GroupByTime("1442093400000", 103)
+          )
+        }
+
+        val fn3 = TimeFormatExtractionFn(
+          granularity = Some(GranularityType.FifteenMinute),
+          format = Some("mm") // minutes
+        )
+        whenReady(request(fn3).execute()) { response =>
+          val list = response.list[GroupByTime]
+          list shouldBe List(
+            GroupByTime("00", 39),
+            GroupByTime("15", 50),
+            GroupByTime("30", 50),
+            GroupByTime("45", 53)
+          )
+        }
+
+        val fn4 = TimeFormatExtractionFn(
+          format = Some("EEEE"),
+          timeZone = Some("America/Montreal"),
+          locale = Some("fr")
+        )
+        whenReady(request(fn4).execute()) { response =>
+          val list = response.list[GroupByTime]
+          list shouldBe List(
+            GroupByTime("samedi", 192)
+          )
+        }
+      }
+    }
+
+    "using TimeParsing" should {
+      "be encoded properly" in {
+        val fn: ExtractionFn = TimeParsingExtractionFn("yyyy-MM-dd", "dd-MM-yy")
+        fn.asJson.noSpaces shouldBe
+        """{"timeFormat":"yyyy-MM-dd","resultFormat":"dd-MM-yy","type":"time"}"""
+      }
+
+      "return formatted timestamp" in new TestContext {
+        def request(extFn: ExtractionFn) =
+          baseRequest(
+            ExtractionDimension(
+              dimension = "__time",
+              outputName = Some("time"),
+              extractionFn = extFn
+            )
+          )
+
+        val fn1: ExtractionFn = TimeParsingExtractionFn(
+          // this basically have no sense, since we haven't got timestamps,
+          // but the result will surprise you
+          timeFormat = "AAA",
+          resultFormat = "EEE, MMM d, HH, ''yy"
+        )
+        whenReady(request(fn1).execute()) { response =>
+          val list = response.list[GroupByTime]
+          list shouldBe List(
+            GroupByTime("Sat, Dec 20, 05, '69", 115),
+            GroupByTime("Sat, Dec 20, 06, '69", 77)
+          )
+        }
+
+        val fn2: ExtractionFn = TimeParsingExtractionFn(
+          // when the timeFormat doesn't suit, it fallbacks to millis
+          timeFormat = "yyyy-MM-dd",
+          resultFormat = "EEE, MMM d, HH,''yy"
+        )
+        whenReady(request(fn2).execute()) { response =>
+          val list = response.list[GroupByTime]
+          list.size shouldBe 192
+          list foreach (_.time.toLong) // no error - value is long
+        }
+      }
+    }
+
+    "using Javascript" should {
+      "be encoded properly" in {
+        val fn: ExtractionFn = JavascriptExtractionFn("function(str) { return str.substr(0, 3); }")
+        fn.asJson.noSpaces shouldBe
+        """{"function":"function(str) { return str.substr(0, 3); }","injective":false,"type":"javascript"}"""
+      }
+    }
+
+    "using Cascade" should {
+      "be encoded properly" in {
+        val fn: ExtractionFn = CascadeExtractionFn(
+          Seq(
+            PartialExtractionFn("ia$"),
+            SubstringExtractionFn(0, Some(4))
+          )
+        )
+        fn.asJson.noSpaces shouldBe
+        """{"extractionFns":[{"expr":"ia$","type":"partial"},{"index":0,"length":4,"type":"substring"}],"type":"cascade"}"""
+      }
+
+      "return item transformed by two functions" in new TestContext {
+        val request =
+          baseRequest(
+            ExtractionDimension(
+              dimension = "countryName",
+              extractionFn = CascadeExtractionFn(
+                Seq(
+                  PartialExtractionFn("ia$"),
+                  SubstringExtractionFn(0, Some(4))
+                )
+              )
+            )
+          )
+
+        whenReady(request.execute()) { response =>
+          val list = response
+            .list[GroupByCountryName]
+            .filter(c => c.countryName.isDefined && c.count > 3)
+          list shouldBe List(
+            GroupByCountryName(Some("Aust"), 4),
+            GroupByCountryName(Some("Colo"), 8),
+            GroupByCountryName(Some("Russ"), 12)
+          )
+        }
+      }
+    }
+
+    "using StringFormat" should {
+      "be encoded properly" in {
+        val fn: ExtractionFn = StringFormatExtractionFn("[%s]", Some(NullHandling.EmptyString))
+        fn.asJson.noSpaces shouldBe
+        """{"format":"[%s]","nullHandling":"emptyString","type":"stringFormat"}"""
+      }
+
+      "return items transformed with function" in new TestContext {
+        def request(nullHandling: NullHandling) =
+          baseRequest(
+            ExtractionDimension(
+              dimension = "countryName",
+              extractionFn = StringFormatExtractionFn("[%s]", Some(nullHandling))
+            )
+          ).copy(filter = None)
+
+        whenReady(request(NullHandling.EmptyString).execute()) { response =>
+          val list = response.list[GroupByCountryName].filter(_.count > 13)
+          list shouldBe List(
+            GroupByCountryName(Some("[France]"), 14),
+            GroupByCountryName(Some("[United States]"), 36),
+            GroupByCountryName(Some("[]"), 1574)
+          )
+        }
+
+        whenReady(request(NullHandling.NullString).execute()) { response =>
+          val list = response.list[GroupByCountryName].filter(_.count > 13)
+          list shouldBe List(
+            GroupByCountryName(Some("[France]"), 14),
+            GroupByCountryName(Some("[United States]"), 36),
+            GroupByCountryName(Some("[null]"), 1574)
+          )
+        }
+
+        whenReady(request(NullHandling.ReturnNull).execute()) { response =>
+          val list = response.list[GroupByCountryName].filter(_.count > 13)
+          list shouldBe List(
+            GroupByCountryName(None, 1574),
+            GroupByCountryName(Some("[France]"), 14),
+            GroupByCountryName(Some("[United States]"), 36)
+          )
+        }
+      }
+    }
+
+    "using Upper" should {
+      "be encoded properly" in {
+        val fn: ExtractionFn = UpperExtractionFn(Some("fr"))
+        fn.asJson.noSpaces shouldBe
+        """{"locale":"fr","type":"upper"}"""
+      }
+
+      "return uppercased items" in new TestContext {
+        val request =
+          baseRequest(
+            ExtractionDimension(
+              dimension = "countryName",
+              extractionFn = UpperExtractionFn()
+            )
+          )
+
+        whenReady(request.execute()) { response =>
+          val list = response.list[GroupByCountryName].filter(_.count > 13)
+          list shouldBe List(
+            GroupByCountryName(Some("FRANCE"), 14),
+            GroupByCountryName(Some("UNITED STATES"), 36)
+          )
+        }
+      }
+    }
+
+    "using Lower" should {
+      "be encoded properly" in {
+        val fn1: ExtractionFn = LowerExtractionFn()
+        fn1.asJson.noSpaces shouldBe
+        """{"locale":null,"type":"lower"}"""
+
+        val fn2: ExtractionFn = LowerExtractionFn(Some("fr"))
+        fn2.asJson.noSpaces shouldBe
+        """{"locale":"fr","type":"lower"}"""
+      }
+
+      "return lowercased items" in new TestContext {
+        val request =
+          baseRequest(
+            ExtractionDimension(
+              dimension = "countryName",
+              extractionFn = LowerExtractionFn()
+            )
+          )
+
+        whenReady(request.execute()) { response =>
+          val list = response.list[GroupByCountryName].filter(_.count > 13)
+          list shouldBe List(
+            GroupByCountryName(Some("france"), 14),
+            GroupByCountryName(Some("united states"), 36)
+          )
+        }
+      }
+    }
+
+    "using Bucket" should {
+      "be encoded properly" in {
+        val fn1: ExtractionFn = BucketExtractionFn()
+        fn1.asJson.noSpaces shouldBe
+        """{"size":1,"offset":0,"type":"bucket"}"""
+
+        val fn2: ExtractionFn = BucketExtractionFn(Some(100), Some(10))
+        fn2.asJson.noSpaces shouldBe
+        """{"size":100,"offset":10,"type":"bucket"}"""
+      }
+
+      "return transformed items" in new TestContext {
+        val request =
+          baseRequest(
+            ExtractionDimension(
+              dimension = "added",
+              outputType = Some("LONG"),
+              extractionFn = BucketExtractionFn(Some(200))
+            ),
+            Dimension("countryName")
+          )
+
+        whenReady(request.execute()) { response =>
+          val list = response.list[GroupByAddedAndCountryName]
+          list.size shouldBe 62
+          list foreach (_.added % 200 shouldBe 0)
+          list.filter(_.added == 800).flatMap(_.countryName.toList) shouldBe List(
+            "Canada",
+            "Mexico",
+            "Philippines",
+            "Poland"
+          )
+        }
+      }
+    }
+
+  }
+}


### PR DESCRIPTION
1. Added Extraction dimension. 
Previous `Dimension` class was renamed to `DefaultDimension`, but is still accessible via `Dimension.apply`, so code `Dimension("dim")` is valid.
2. Added all extraction functions 
except "searchQuery", "lookup" and "registeredLookup": these are tightly coupled with respective query types, and I decided not to implement them in this PR.

Extraction fucntions are in its separate file for two reasons: 
1. It is a big piece of code to place it inside `Dimension.scala`.
2. Some of the functions could be used in [Filters](http://druid.io/docs/latest/querying/filters.html#filtering-with-extraction-functions), so these functions could be a common thing for different parts of the project. (Marker traits could be used for distinction, or smth like that)


`logback-test.xml` was added to get rid of huge amount of logs while tests are running.