### PR TITLE
Post-aggregations

### DIFF
--- a/src/main/scala/ing/wbaa/druid/DruidQuery.scala
+++ b/src/main/scala/ing/wbaa/druid/DruidQuery.scala
@@ -62,7 +62,8 @@ case class GroupByQuery(
     dimensions: List[Dimension] = List(),
     granularity: Granularity = GranularityType.All,
     dataSource: String = DruidConfig.datasource,
-    having: Option[Having] = None
+    having: Option[Having] = None,
+    postAggregations: List[PostAggregation] = Nil
 ) extends DruidQuery {
   val queryType = QueryType.GroupBy
 }
@@ -87,7 +88,7 @@ case class TopNQuery(
     granularity: Granularity = GranularityType.All,
     filter: Option[Filter] = None,
     dataSource: String = DruidConfig.datasource,
-    postAggregations: List[PostAggregation] = List()
+    postAggregations: List[PostAggregation] = Nil
 ) extends DruidQuery {
   val queryType = QueryType.TopN
 }

--- a/src/main/scala/ing/wbaa/druid/definitions/Aggregation.scala
+++ b/src/main/scala/ing/wbaa/druid/definitions/Aggregation.scala
@@ -44,7 +44,7 @@ object AggregationType extends EnumCodec[AggregationType] {
   val values: Set[AggregationType] = sealerate.values[AggregationType]
 }
 
-trait Aggregation {
+sealed trait Aggregation {
   val `type`: AggregationType
   val name: String
 }

--- a/src/main/scala/ing/wbaa/druid/definitions/PostAggregation.scala
+++ b/src/main/scala/ing/wbaa/druid/definitions/PostAggregation.scala
@@ -19,63 +19,183 @@ package ing.wbaa.druid
 package definitions
 
 import ca.mrvisser.sealerate
-import io.circe._
+import ing.wbaa.druid.definitions.ArithmeticFunction.{ DIV, MINUS, MULT, PLUS, QUOT }
+import ing.wbaa.druid.definitions.Ordering.FloatingPoint
+import io.circe.Encoder
 import io.circe.generic.auto._
 import io.circe.syntax._
 
 sealed trait PostAggregationType extends Enum with CamelCaseEnumStringEncoder
 object PostAggregationType extends EnumCodec[PostAggregationType] {
-  case object Arithmetic extends PostAggregationType
+  case object Arithmetic             extends PostAggregationType
+  case object FieldAccess            extends PostAggregationType
+  case object FinalizingFieldAccess  extends PostAggregationType
+  case object Constant               extends PostAggregationType
+  case object DoubleGreatest         extends PostAggregationType
+  case object LongGreatest           extends PostAggregationType
+  case object DoubleLeast            extends PostAggregationType
+  case object LongLeast              extends PostAggregationType
+  case object Javascript             extends PostAggregationType
+  case object HyperUniqueCardinality extends PostAggregationType
 
-  val values: Set[PostAggregationType] = sealerate.values[PostAggregationType]
+  override val values: Set[PostAggregationType] = sealerate.values[PostAggregationType]
 }
 
-trait PostAggregation {
+sealed trait PostAggregation {
   val `type`: PostAggregationType
-  val name: String
+}
+
+sealed trait Ordering
+object Ordering {
+  case object FloatingPoint extends Ordering
+  case object NumericFirst  extends Ordering
+
+  implicit val encoder: Encoder[Ordering] = new Encoder[Ordering] {
+    override def apply(o: Ordering) = o match {
+      case FloatingPoint => io.circe.Json.Null
+      case NumericFirst  => "numericFirst".asJson
+    }
+  }
+}
+
+sealed trait ArithmeticFunction {
+  val value: String
+}
+object ArithmeticFunction {
+  case object PLUS extends ArithmeticFunction {
+    override val value = "+"
+  }
+  case object MINUS extends ArithmeticFunction {
+    override val value = "-"
+  }
+  case object MULT extends ArithmeticFunction {
+    override val value = "*"
+  }
+  case object DIV extends ArithmeticFunction {
+    override val value = "/"
+  }
+  case object QUOT extends ArithmeticFunction {
+    override val value = "quotient"
+  }
+
+  implicit val encoder: Encoder[ArithmeticFunction] = new Encoder[ArithmeticFunction] {
+    override def apply(a: ArithmeticFunction) = a.value.asJson
+  }
+}
+
+case class ArithmeticPostAggregation(
+    name: String,
+    fn: ArithmeticFunction,
+    fields: Seq[PostAggregation],
+    ordering: Option[Ordering] = Some(FloatingPoint)
+) extends PostAggregation {
+  override val `type` = PostAggregationType.Arithmetic
+
+  def withName(name: String): ArithmeticPostAggregation = copy(name = name)
+
+  def withOrdering(ordering: Ordering): ArithmeticPostAggregation = copy(ordering = Some(ordering))
+}
+
+case class FieldAccessPostAggregation(
+    fieldName: String,
+    name: Option[String] = None
+) extends PostAggregation {
+  override val `type` = PostAggregationType.FieldAccess
+}
+
+case class FinalizingFieldAccessPostAggregation(
+    fieldName: String,
+    name: Option[String] = None
+) extends PostAggregation {
+  override val `type` = PostAggregationType.FinalizingFieldAccess
+}
+
+case class ConstantPostAggregation(
+    value: Double,
+    name: Option[String] = None
+) extends PostAggregation {
+  override val `type` = PostAggregationType.Constant
+}
+
+case class DoubleGreatestPostAggregation(
+    name: String,
+    fields: Seq[PostAggregation]
+) extends PostAggregation {
+  override val `type` = PostAggregationType.DoubleGreatest
+}
+
+case class LongGreatestPostAggregation(
+    name: String,
+    fields: Seq[PostAggregation]
+) extends PostAggregation {
+  override val `type` = PostAggregationType.LongGreatest
+}
+
+case class DoubleLeastPostAggregation(
+    name: String,
+    fields: Seq[PostAggregation]
+) extends PostAggregation {
+  override val `type` = PostAggregationType.DoubleLeast
+}
+
+case class LongLeastPostAggregation(
+    name: String,
+    fields: Seq[PostAggregation]
+) extends PostAggregation {
+  override val `type` = PostAggregationType.LongLeast
+}
+
+case class JavascriptPostAggregation(
+    name: String,
+    fieldNames: Seq[String],
+    function: String
+) extends PostAggregation {
+  override val `type` = PostAggregationType.Javascript
 }
 
 object PostAggregation {
   implicit val encoder: Encoder[PostAggregation] = new Encoder[PostAggregation] {
-    final def apply(pAgg: PostAggregation): Json =
-      (pAgg match {
-        case x: ArithmeticPostAggregation => x.asJsonObject
-      }).add("type", pAgg.`type`.asJson).asJson
+    override def apply(pa: PostAggregation) =
+      (pa match {
+        case x: ArithmeticPostAggregation            => x.asJsonObject
+        case x: FieldAccessPostAggregation           => x.asJsonObject
+        case x: FinalizingFieldAccessPostAggregation => x.asJsonObject
+        case x: ConstantPostAggregation              => x.asJsonObject
+        case x: DoubleGreatestPostAggregation        => x.asJsonObject
+        case x: LongGreatestPostAggregation          => x.asJsonObject
+        case x: DoubleLeastPostAggregation           => x.asJsonObject
+        case x: LongLeastPostAggregation             => x.asJsonObject
+        case x: JavascriptPostAggregation            => x.asJsonObject
+      }).add("type", pa.`type`.asJson).asJson
   }
 }
 
-case class ArithmeticPostAggregation(name: String,
-                                     fn: String,
-                                     fields: (PostAggregator, PostAggregator))
-    extends PostAggregation {
-  override val `type` = PostAggregationType.Arithmetic
-}
+object ArithmeticFunctions {
+  def -(l: PostAggregation, r: PostAggregation): ArithmeticPostAggregation =
+    ArithmeticPostAggregation("", MINUS, Seq(l, r))
 
-sealed trait PostAggregatorType extends Enum with CamelCaseEnumStringEncoder
-object PostAggregatorType extends EnumCodec[PostAggregatorType] {
-  case object FieldAccess extends PostAggregatorType
-  case object Constant    extends PostAggregatorType
+  def +(l: PostAggregation, r: PostAggregation): ArithmeticPostAggregation =
+    ArithmeticPostAggregation("", PLUS, Seq(l, r))
 
-  val values: Set[PostAggregatorType] = sealerate.values[PostAggregatorType]
-}
+  def *(l: PostAggregation, r: PostAggregation): ArithmeticPostAggregation =
+    ArithmeticPostAggregation("", MULT, Seq(l, r))
 
-trait PostAggregator {
-  val `type`: PostAggregatorType
-  val name: String
-}
+  def /(l: PostAggregation, r: PostAggregation): ArithmeticPostAggregation =
+    ArithmeticPostAggregation("", DIV, Seq(l, r))
 
-object PostAggregator {
-  implicit val encoder: Encoder[PostAggregator] = new Encoder[PostAggregator] {
-    final def apply(field: PostAggregator): Json =
-      (field match {
-        case x: FieldAccessPostAggregator => x.asJsonObject
-        case x: ConstantPostAggregator    => x.asJsonObject
-      }).add("type", field.`type`.asJson).asJson
+  def quot(l: PostAggregation, r: PostAggregation): ArithmeticPostAggregation =
+    ArithmeticPostAggregation("", QUOT, Seq(l, r))
+
+  implicit class ArithmeticFunctionsOps(pa: PostAggregation) {
+    def -(other: PostAggregation): ArithmeticPostAggregation = ArithmeticFunctions.-(pa, other)
+
+    def +(other: PostAggregation): ArithmeticPostAggregation = ArithmeticFunctions.+(pa, other)
+
+    def *(other: PostAggregation): ArithmeticPostAggregation = ArithmeticFunctions.*(pa, other)
+
+    def /(other: PostAggregation): ArithmeticPostAggregation = ArithmeticFunctions./(pa, other)
+
+    def quot(other: PostAggregation): ArithmeticPostAggregation =
+      ArithmeticFunctions.quot(pa, other)
   }
-}
-case class FieldAccessPostAggregator(name: String, fieldName: String) extends PostAggregator {
-  override val `type`: PostAggregatorType = PostAggregatorType.FieldAccess
-}
-case class ConstantPostAggregator(name: String, value: Double) extends PostAggregator {
-  override val `type`: PostAggregatorType = PostAggregatorType.Constant
 }

--- a/src/test/scala/ing/wbaa/druid/DruidQuerySpec.scala
+++ b/src/test/scala/ing/wbaa/druid/DruidQuerySpec.scala
@@ -17,12 +17,13 @@
 
 package ing.wbaa.druid
 
+import ing.wbaa.druid.definitions.ArithmeticFunctions._
+import ing.wbaa.druid.definitions.FilterOperators._
+import ing.wbaa.druid.definitions._
+import io.circe.generic.auto._
 import org.scalatest._
 import org.scalatest.concurrent._
 import org.scalatest.time._
-import ing.wbaa.druid.definitions._
-import io.circe.generic.auto._
-import ing.wbaa.druid.definitions.FilterOperators._
 
 class DruidQuerySpec extends WordSpec with Matchers with ScalaFutures {
   implicit override val patienceConfig =
@@ -233,13 +234,8 @@ class DruidQuerySpec extends WordSpec with Matchers with ScalaFutures {
           LongSumAggregation(name = "count", fieldName = "count")
         ),
         postAggregations = List(
-          ArithmeticPostAggregation(name = "halfCount",
-                                    fn = "/",
-                                    fields = (
-                                      FieldAccessPostAggregator(name = "count",
-                                                                fieldName = "count"),
-                                      ConstantPostAggregator(name = "two", value = 2)
-                                    ))
+          (FieldAccessPostAggregation("count") / ConstantPostAggregation(2))
+            .withName("halfCount")
         ),
         intervals = List("2011-06-01/2017-06-01")
       ).execute

--- a/src/test/scala/ing/wbaa/druid/definitions/PostAggregationSpec.scala
+++ b/src/test/scala/ing/wbaa/druid/definitions/PostAggregationSpec.scala
@@ -1,0 +1,419 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ing.wbaa.druid.definitions
+
+import ing.wbaa.druid.GroupByQuery
+import ing.wbaa.druid.definitions.ArithmeticFunction.{ DIV, MINUS, MULT, PLUS, QUOT }
+import ing.wbaa.druid.definitions.ArithmeticFunctions._
+import ing.wbaa.druid.definitions.FilterOperators._
+import io.circe.generic.auto._
+import io.circe.syntax._
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.{ Matchers, WordSpecLike }
+
+import scala.concurrent.duration._
+import scala.language.postfixOps
+
+class PostAggregationSpec extends Matchers with WordSpecLike with ScalaFutures {
+
+  override implicit def patienceConfig: PatienceConfig = PatienceConfig(10 seconds, 100 millis)
+
+  final case class Aggregated(count: Double,
+                              added: Double,
+                              deleted: Double,
+                              result: Double,
+                              countryName: String)
+  final case class ConstantlyAggregated(constant: Double, countryName: String)
+
+  sealed trait TestContext {
+    def baseRequest(pas: PostAggregation*): GroupByQuery = GroupByQuery(
+      aggregations = List(
+        LongSumAggregation("count", "count"),
+        LongSumAggregation("added", "added"),
+        LongSumAggregation("deleted", "deleted")
+      ),
+      intervals = List("2010-09-12T21:00:00/2020-09-12T22:00:00"),
+      granularity = GranularityType.Hour,
+      dimensions = List(Dimension("countryName")),
+      filter = Some(!SelectFilter("countryName", "")),
+      postAggregations = pas.toList
+    )
+  }
+
+  "Ordering" should {
+    "be encoded properly" in {
+      val ord1: Ordering = Ordering.NumericFirst
+      ord1.asJson.noSpaces shouldBe "\"numericFirst\""
+
+      val ord2: Ordering = Ordering.FloatingPoint
+      ord2.asJson.noSpaces shouldBe "null"
+    }
+  }
+
+  "PostAggregation" when {
+    "it is Arithmetic" should {
+      "add name and ordering" in {
+        ArithmeticPostAggregation("", PLUS, Nil).withName("name") shouldBe ArithmeticPostAggregation(
+          "name",
+          PLUS,
+          Nil
+        )
+        ArithmeticPostAggregation("", PLUS, Nil).withOrdering(Ordering.NumericFirst) shouldBe ArithmeticPostAggregation(
+          "",
+          PLUS,
+          Nil,
+          Some(Ordering.NumericFirst)
+        )
+      }
+
+      "be encoded properly" in {
+        val pa: PostAggregation = ArithmeticPostAggregation(
+          "total",
+          PLUS,
+          Seq(
+            FieldAccessPostAggregation("a"),
+            FieldAccessPostAggregation("b")
+          )
+        )
+
+        pa.asJson.noSpaces shouldBe
+        """{"name":"total","fn":"+","fields":[{"fieldName":"a","name":null,"type":"fieldAccess"},{"fieldName":"b","name":null,"type":"fieldAccess"}],"ordering":null,"type":"arithmetic"}"""
+      }
+
+      "return items transformed with arithmetic post-aggregation" in new TestContext {
+        val request = baseRequest(
+          ArithmeticPostAggregation(
+            "result",
+            PLUS,
+            Seq(FieldAccessPostAggregation("added"), FieldAccessPostAggregation("deleted"))
+          )
+        ).copy(
+          having = Some(GreaterThanHaving("added", 18000))
+        )
+
+        whenReady(request.execute()) { response =>
+          val list = response.list[Aggregated]
+          list shouldBe List(
+            Aggregated(1, 18936, 0, 18936, "Bulgaria"),
+            Aggregated(14, 40426, 566, 40992, "Colombia")
+          )
+        }
+      }
+    }
+
+    "it is FieldAccessor" should {
+      "be encoded properly" in {
+        val pa1: PostAggregation = FieldAccessPostAggregation("b")
+        pa1.asJson.noSpaces shouldBe """{"fieldName":"b","name":null,"type":"fieldAccess"}"""
+
+        val pa2: PostAggregation = FieldAccessPostAggregation("a", Some("b"))
+        pa2.asJson.noSpaces shouldBe """{"fieldName":"a","name":"b","type":"fieldAccess"}"""
+      }
+    }
+
+    "it is FinalizingFieldAccessor" should {
+      "be encoded properly" in {
+        val pa: PostAggregation = FinalizingFieldAccessPostAggregation("a")
+        pa.asJson.noSpaces shouldBe """{"fieldName":"a","name":null,"type":"finalizingFieldAccess"}"""
+      }
+    }
+
+    "it is Constant" should {
+      "be encoded properly" in {
+        val pa: PostAggregation = ConstantPostAggregation(100, Some("a"))
+        pa.asJson.noSpaces shouldBe """{"value":100.0,"name":"a","type":"constant"}"""
+      }
+
+      "return items transformed with constant post-aggregation" in new TestContext {
+        val request = baseRequest(
+          ConstantPostAggregation(3.14159, Some("constant"))
+        ).copy(
+          having = Some(GreaterThanHaving("added", 18000))
+        )
+
+        whenReady(request.execute()) { response =>
+          val list = response.list[ConstantlyAggregated]
+          list shouldBe List(
+            ConstantlyAggregated(3.14159, "Bulgaria"),
+            ConstantlyAggregated(3.14159, "Colombia")
+          )
+        }
+      }
+    }
+
+    "it is DoubleGreatestPA" should {
+      "be encoded properly" in {
+        val pa: PostAggregation =
+          DoubleGreatestPostAggregation("greatest",
+                                        Seq(ConstantPostAggregation(10.1),
+                                            ConstantPostAggregation(10.2)))
+        pa.asJson.noSpaces shouldBe """{"name":"greatest","fields":[{"value":10.1,"name":null,"type":"constant"},{"value":10.2,"name":null,"type":"constant"}],"type":"doubleGreatest"}"""
+      }
+
+      "return items transformed with doubleGreatest post-aggregation" in new TestContext {
+        val request = baseRequest(
+          DoubleGreatestPostAggregation("constant",
+                                        Seq(ConstantPostAggregation(10.1),
+                                            ConstantPostAggregation(10.2)))
+        ).copy(
+          having = Some(GreaterThanHaving("added", 18000))
+        )
+
+        whenReady(request.execute()) { response =>
+          val list = response.list[ConstantlyAggregated]
+          list shouldBe List(
+            ConstantlyAggregated(10.2, "Bulgaria"),
+            ConstantlyAggregated(10.2, "Colombia")
+          )
+        }
+      }
+    }
+
+    "it is LongGreatestPA" should {
+      "be encoded properly" in {
+        val pa: PostAggregation =
+          LongGreatestPostAggregation("greatest",
+                                      Seq(ConstantPostAggregation(10), ConstantPostAggregation(12)))
+        pa.asJson.noSpaces shouldBe """{"name":"greatest","fields":[{"value":10.0,"name":null,"type":"constant"},{"value":12.0,"name":null,"type":"constant"}],"type":"longGreatest"}"""
+      }
+
+      "return items transformed with longGreatest post-aggregation with long values" in new TestContext {
+        val request = baseRequest(
+          LongGreatestPostAggregation("constant",
+                                      Seq(ConstantPostAggregation(10), ConstantPostAggregation(11)))
+        ).copy(
+          having = Some(GreaterThanHaving("added", 18000))
+        )
+
+        whenReady(request.execute()) { response =>
+          val list = response.list[ConstantlyAggregated]
+          list shouldBe List(
+            ConstantlyAggregated(11, "Bulgaria"),
+            ConstantlyAggregated(11, "Colombia")
+          )
+        }
+      }
+
+      "return items transformed with longGreatest post-aggregation with double values" in new TestContext {
+        val request = baseRequest(
+          LongGreatestPostAggregation("constant",
+                                      Seq(ConstantPostAggregation(10.1),
+                                          ConstantPostAggregation(10.2)))
+        ).copy(
+          having = Some(GreaterThanHaving("added", 18000))
+        )
+
+        whenReady(request.execute()) { response =>
+          val list = response.list[ConstantlyAggregated]
+          list shouldBe List(
+            ConstantlyAggregated(10, "Bulgaria"),
+            ConstantlyAggregated(10, "Colombia")
+          )
+        }
+      }
+    }
+
+    "it is DoubleLeastPA" should {
+      "be encoded properly" in {
+        val pa: PostAggregation =
+          DoubleLeastPostAggregation("least",
+                                     Seq(ConstantPostAggregation(10.1),
+                                         ConstantPostAggregation(10.2)))
+        pa.asJson.noSpaces shouldBe """{"name":"least","fields":[{"value":10.1,"name":null,"type":"constant"},{"value":10.2,"name":null,"type":"constant"}],"type":"doubleLeast"}"""
+      }
+
+      "return items transformed with doubleLeast post-aggregation" in new TestContext {
+        val request = baseRequest(
+          DoubleLeastPostAggregation("constant",
+                                     Seq(ConstantPostAggregation(10.1),
+                                         ConstantPostAggregation(10.2)))
+        ).copy(
+          having = Some(GreaterThanHaving("added", 18000))
+        )
+
+        whenReady(request.execute()) { response =>
+          val list = response.list[ConstantlyAggregated]
+          list shouldBe List(
+            ConstantlyAggregated(10.1, "Bulgaria"),
+            ConstantlyAggregated(10.1, "Colombia")
+          )
+        }
+      }
+    }
+
+    "it is LongLeastPA" should {
+      "be encoded properly" in {
+        val pa: PostAggregation =
+          LongLeastPostAggregation("least",
+                                   Seq(ConstantPostAggregation(10), ConstantPostAggregation(12)))
+        pa.asJson.noSpaces shouldBe """{"name":"least","fields":[{"value":10.0,"name":null,"type":"constant"},{"value":12.0,"name":null,"type":"constant"}],"type":"longLeast"}"""
+      }
+
+      "return items transformed with longLeast post-aggregation with long values" in new TestContext {
+        val request = baseRequest(
+          LongLeastPostAggregation("constant",
+                                   Seq(ConstantPostAggregation(10), ConstantPostAggregation(11)))
+        ).copy(
+          having = Some(GreaterThanHaving("added", 18000))
+        )
+
+        whenReady(request.execute()) { response =>
+          val list = response.list[ConstantlyAggregated]
+          list shouldBe List(
+            ConstantlyAggregated(10, "Bulgaria"),
+            ConstantlyAggregated(10, "Colombia")
+          )
+        }
+      }
+
+      "return items transformed with longLeast post-aggregation with double values" in new TestContext {
+        val request = baseRequest(
+          LongLeastPostAggregation(
+            "constant",
+            Seq(
+              ConstantPostAggregation(10.1),
+              ConstantPostAggregation(10.2)
+            )
+          )
+        ).copy(
+          having = Some(GreaterThanHaving("added", 18000))
+        )
+
+        whenReady(request.execute()) { response =>
+          val list = response.list[ConstantlyAggregated]
+          list shouldBe List(
+            ConstantlyAggregated(10, "Bulgaria"),
+            ConstantlyAggregated(10, "Colombia")
+          )
+        }
+      }
+    }
+
+    "it is JavascriptPA" should {
+      "be encoded properly" in {
+        val pa: PostAggregation = JavascriptPostAggregation(
+          "least",
+          Seq("str1", "str2"),
+          "function(a, b) { return a + b; }"
+        )
+        pa.asJson.noSpaces shouldBe
+        """{"name":"least","fieldNames":["str1","str2"],"function":"function(a, b) { return a + b; }","type":"javascript"}"""
+      }
+    }
+  }
+
+  "ArithmeticOperators" when {
+    sealed trait OperatorsContext {
+      val a = ConstantPostAggregation(1.0)
+      val b = ConstantPostAggregation(2.0)
+      val c = ConstantPostAggregation(3.0)
+    }
+
+    "using +" should {
+      "be encoded" in {
+        val op: ArithmeticFunction = PLUS
+        op.asJson.noSpaces shouldBe "\"+\""
+      }
+
+      "compose properly" in new OperatorsContext {
+        a + b shouldBe ArithmeticPostAggregation("", PLUS, Seq(a, b))
+      }
+    }
+
+    "using -" should {
+      "be encoded" in {
+        val op: ArithmeticFunction = MINUS
+        op.asJson.noSpaces shouldBe "\"-\""
+      }
+
+      "compose properly" in new OperatorsContext {
+        a - b shouldBe ArithmeticPostAggregation("", MINUS, Seq(a, b))
+      }
+    }
+
+    "using *" should {
+      "be encoded" in {
+        val op: ArithmeticFunction = MULT
+        op.asJson.noSpaces shouldBe "\"*" +
+        "\""
+      }
+
+      "compose properly" in new OperatorsContext {
+        a * b shouldBe ArithmeticPostAggregation("", MULT, Seq(a, b))
+      }
+    }
+
+    "using /" should {
+      "be encoded" in {
+        val op: ArithmeticFunction = DIV
+        op.asJson.noSpaces shouldBe "\"/\""
+      }
+
+      "compose properly" in new OperatorsContext {
+        a / b shouldBe ArithmeticPostAggregation("", DIV, Seq(a, b))
+      }
+    }
+
+    "using quot" should {
+      "be encoded" in {
+        val op: ArithmeticFunction = QUOT
+        op.asJson.noSpaces shouldBe "\"quotient\""
+      }
+
+      "compose properly" in new OperatorsContext {
+        a quot b shouldBe ArithmeticPostAggregation("", QUOT, Seq(a, b))
+      }
+    }
+
+    "using multiple operators" should {
+      "do precedence properly" in new OperatorsContext {
+        a + b * c shouldBe
+        ArithmeticPostAggregation("",
+                                  PLUS,
+                                  Seq(
+                                    a,
+                                    ArithmeticPostAggregation("", MULT, Seq(b, c))
+                                  ))
+
+        a * b + c shouldBe
+        ArithmeticPostAggregation("",
+                                  PLUS,
+                                  Seq(
+                                    ArithmeticPostAggregation("", MULT, Seq(a, b)),
+                                    c
+                                  ))
+
+        (a + b) * c shouldBe
+        ArithmeticPostAggregation("",
+                                  MULT,
+                                  Seq(
+                                    ArithmeticPostAggregation("", PLUS, Seq(a, b)),
+                                    c
+                                  ))
+
+        a quot b + c shouldBe
+        ArithmeticPostAggregation("",
+                                  QUOT,
+                                  Seq(
+                                    a,
+                                    ArithmeticPostAggregation("", PLUS, Seq(b, c))
+                                  ))
+      }
+    }
+  }
+}


### PR DESCRIPTION
1) Added all post-aggregations from Druid documetation except just one: HyperUnique Cardinality. Simply because we dont have aggregations of the same type, and not to confuse users. Anyway, it can be added later without any troubles.
2) Arithmetic functions for `ArithmeticPostAggregation` are coded as a separate family of case classes. It gives users only the defined set of functions to choose from, and not put "blah-blah" into `function` field.
3) Added implicit conversions for arithmetic functions, as it have been already done for Filters and Havings. Precedence of operators of course is preserved, but remember that `quotient` has the lowest precedence, when using implicit conversions. 