### PR TITLE
Improved configuration

### DIFF
--- a/src/main/scala/ing/wbaa/druid/DruidConfig.scala
+++ b/src/main/scala/ing/wbaa/druid/DruidConfig.scala
@@ -1,17 +1,19 @@
-// * Licensed to the Apache Software Foundation (ASF) under one or more
-// * contributor license agreements.  See the NOTICE file distributed with
-// * this work for additional information regarding copyright ownership.
-// * The ASF licenses this file to You under the Apache License, Version 2.0
-// * (the "License"); you may not use this file except in compliance with
-// * the License.  You may obtain a copy of the License at
-// *
-// *    http://www.apache.org/licenses/LICENSE-2.0
-// *
-// * Unless required by applicable law or agreed to in writing, software
-// * distributed under the License is distributed on an "AS IS" BASIS,
-// * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// * See the License for the specific language governing permissions and
-// * limitations under the License.
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package ing.wbaa.druid
 
@@ -23,18 +25,29 @@ import scala.language.implicitConversions
 /*
  * Druid API Config Immutable
  */
+class DruidConfig(val host: String,
+                  val port: Int,
+                  val secure: Boolean,
+                  val url: String,
+                  val datasource: String,
+                  val responseParsingTimeout: FiniteDuration)
+
 object DruidConfig {
-  implicit def asFiniteDuration(d: java.time.Duration): FiniteDuration =
-    scala.concurrent.duration.Duration.fromNanos(d.toNanos)
 
   private val config      = ConfigFactory.load()
   private val druidConfig = config.getConfig("druid")
 
-  /** Druid url */
-  val host: String                           = druidConfig.getString("host")
-  val port: Int                              = druidConfig.getInt("port")
-  val secure: Boolean                        = druidConfig.getBoolean("secure")
-  val url: String                            = druidConfig.getString("url")
-  val datasource: String                     = druidConfig.getString("datasource")
-  val responseParsingTimeout: FiniteDuration = druidConfig.getDuration("response-parsing-timeout")
+  implicit def asFiniteDuration(d: java.time.Duration): FiniteDuration =
+    scala.concurrent.duration.Duration.fromNanos(d.toNanos)
+
+  implicit val DefaultConfig: DruidConfig = apply()
+
+  def apply(host: String = druidConfig.getString("host"),
+            port: Int = druidConfig.getInt("port"),
+            secure: Boolean = druidConfig.getBoolean("secure"),
+            url: String = druidConfig.getString("url"),
+            datasource: String = druidConfig.getString("datasource"),
+            responseParsingTimeout: FiniteDuration =
+              druidConfig.getDuration("response-parsing-timeout")): DruidConfig =
+    new DruidConfig(host, port, secure, url, datasource, responseParsingTimeout)
 }


### PR DESCRIPTION
Hi,

I would like to propose some improvements to the configuration of the Scruid library. The improvements are backward compatible with the current implementation. The only difference is that we can override any configuration parameter by defining an implicit instance of `ing.wbaa.druid.DruidConfig`.

Consider, for example, the following code:

```
import java.time.ZonedDateTime
import ing.wbaa.druid._
import scala.concurrent.duration._
import ing.wbaa.druid.definitions._

implicit val druidConf = DruidConfig(
  datasource = "some_different_datasource",
  responseParsingTimeout = 10.seconds
)
        
case class TimeseriesCount(count: Int)

val response = TimeSeriesQuery(
  aggregations = List(
    CountAggregation(name = "count")
  ),
  granularity = GranularityType.Week,
  intervals = List("2011-06-01/2017-06-01")
).execute()

val series: Map[ZonedDateTime, TimeseriesCount] = response.series[TimeseriesCount]    
```

The implicit configuration overrides the settings of application.conf or reference.conf. This can be practical for scala/ammonite scripts or notebooks, in which we would like to quickly set the settings inside the script/notebook.
