### PR TITLE
Druid Query Language (DQL)

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,28 @@ val series: Map[ZonedDateTime, TimeseriesCount] = response.series[TimeseriesCoun
 
 To get the timeseries data from this `Future[DruidRespones]` you can run `val series = result.series[TimeseriesCount]`.
 
+## Druid query language (DQL)
+
+Scruid also provides a rich Scala API for building queries using the fluent pattern.
+
+```
+case class GroupByIsAnonymous(isAnonymous: String, country: String, count: Int)
+
+val query: GroupByQuery = DQL
+    .granularity(GranularityType.Day)
+    .interval("2011-06-01/2017-06-01")
+    .agg(count as "count")
+    .where('countryName.isNotNull)
+    .groupBy('isAnonymous, 'countryName.extract(UpperExtractionFn()) as "country")
+    .having('count > 100 and 'count < 200)
+    .limit(10, 'count.desc(DimensionOrderType.Numeric))
+    .build()
+      
+val response: Future[List[GroupByIsAnonymous]] = query.execute().map(_.list[GroupByIsAnonymous])
+```
+ 
+For details and examples see the [DQL documentation](docs/dql.md). 
+
 ## Configuration
 
 The configuration is done by [Typesafe config](https://github.com/typesafehub/config). The configuration can be overridden by using environment variables, e.g. `DRUID_HOST`, `DRUID_PORT` and `DRUID_DATASOURCE`. Or by placing an application.conf in your own project and this will override the reference.conf of the scruid library.

--- a/docs/dql.md
+++ b/docs/dql.md
@@ -1,0 +1,626 @@
+# Druid query language (DQL)
+
+Scruid provides a rich Scala API for building queries using the fluent pattern.
+
+In order to use DQL, you have to import `ing.wbaa.druid.dql.DSL._` and thereafter build a query using the `DQL` query 
+builder. The type of the query can be time-series (default), group-by or top-n.  
+
+For all three types of queries you can define the following:
+ 
+ - The datasource name to perform the query, or defaults to the one that has been defined in the configuration.
+ - The granularity of the query, e.g., `Hour`, `Day`, `Week`, etc (default is `Week` for time-series and `All` 
+ for top-n and group-by).
+ - The interval of the query, expressed as [ISO-8601 intervals](https://en.wikipedia.org/wiki/ISO_8601).
+ - Filter dimensions
+ - Aggregations and post-aggregations
+
+For example, consider the following fragment of a DQL query:
+
+```
+import ing.wbaa.druid.definitions.GranularityType
+import ing.wbaa.druid.dql.DSL._
+
+val query = DQL
+  .from("wikiticker")
+  .granularity(GranularityType.Hour)
+  .interval("2011-06-01/2017-06-01")
+  .where('countryName === "Italy" or 'countryName === "Greece")
+  .agg(count as "agg_count")
+  .postAgg(('agg_count / 2) as "halfCount")
+  //...
+```
+
+Function `from` defines the datasource to use, `granularity` defines the granularity of the query, `interval` defines the 
+temporal interval of the data expressed in ISO-8601, `where` defines which rows of data should be included in the 
+computation for a query, `agg` defines functions that summarize data (e.g., count of rows) and `postAgg` defines 
+specifications of processing that should happen on aggregated values. 
+
+In the above example we are performing a query over the datasource `wikiticker`, using hourly granularity, for the 
+interval `2011-06-01` until `2017-06-01`. We are considering rows of data where the value of dimension `countryName` 
+is either `Italy` or `Greece`. Furthermore, we are interested in half counting the rows. To achieve that we define 
+the aggregation function `count` we name it as `agg_count` and thereafter we define a post-aggregation function named 
+as `halfCount` that takes the result of `agg_count` and divides it by `2`.
+
+The equivalent fragment of a Druid query expressed in JSON is given below:
+
+```
+{
+  "dataSource" : "wikiticker",
+  "granularity" : "hour",
+  "intervals" : [ "2011-06-01/2017-06-01"],
+  "filter" : {
+      "fields" : [
+        {
+          "dimension" : "countryName",
+          "value" : "Italy",
+          "type" : "selector"
+        },
+        {
+          "dimension" : "countryName",
+          "value" : "Greece",
+          "type" : "selector"
+        }
+      ],
+      "type" : "or"
+   },
+  "aggregations" : [
+    {
+      "name" : "agg_count",
+      "type" : "count"
+    }
+  ],
+  "postAggregations" : [
+    {
+      "name" : "halfCount",
+      "fn" : "/",
+      "fields" : [
+        {
+          "name" : "agg_count",
+          "fieldName" : "agg_count",
+          "type" : "fieldAccess"
+        },
+        {
+          "name" : "c_2.0",
+          "value" : 2.0,
+          "type" : "constant"
+        }
+      ],
+      "type" : "arithmetic"
+    }
+  ]
+}
+```
+
+Dimensions can be represented using Scala symbols, e.g., \`countryName, or by using function `dim`, 
+e.g., `dim("countryName")` or as a String prefix function symbol `d`, e.g., `d"countryName"`. In the latter case
+it is possible to pass a string with variables in order to perform string interpolation, for example:
+
+```
+val prefix = "country"
+
+DQL.where(d"${prefix}Name" === "Greece")
+```
+
+### Operators
+
+In `where` function you can define the following operators to filter the rows of data in a query.
+
+
+#### Equals
+
+| Example                                    | Description                                                             |
+|--------------------------------------------|-------------------------------------------------------------------------|
+| `'countryName === "Greece"`                | the value of dimension `countryName` equals to "Greece"                 |
+| `'dim === 10`                              | the value of dimension `dim` equals to 10                               |
+| `'dim === 10.1`                            | the value of dimension `dim` equals to 10.1                             |
+| `'dim1 === 'dim2`                          | the values of dimensions `'dim1` and `'dim2` are equal                  |
+
+#### Not equals
+
+| Example                                    | Description                                                             |
+|--------------------------------------------|-------------------------------------------------------------------------|
+| `'countryName =!= "Greece"`                | the value of dimension `countryName` not equals to "Greece"             |
+| `'dim =!= 10`                              | the value of dimension `dim` not equals to 10                           |
+| `'dim =!= 10.1`                            | the value of dimension `dim` not equals to 10.1                         |
+| `'dim1 =!= 'dim2`                          | the values of dimensions`'dim1` and `'dim2` are not equal               |
+
+
+#### Regular expression
+
+It matches the specified dimension with the given pattern. The pattern can be any standard [Java regular expression](https://docs.oracle.com/javase/6/docs/api/java/util/regex/Pattern.html). 
+For example, match a floating point number from a string:
+
+```
+'dim regex "\\d+(\\.\\d+)"
+```
+
+#### Like
+
+Like operators can be used for basic wildcard searches. They are equivalent to the `SQL LIKE` operator. For example,
+match all last names that start with character 'S'. 
+
+```
+'lastName like "S%"
+```
+
+#### Search
+
+Search operators can be used to filter on partial string matches. For example, for case sensitive search (default):
+
+```
+'dim contains "some string"
+
+// which is equivalent to:
+'dim contains("some string", caseSensitive = true)
+```
+
+Similarly, to ignore case sensitivity in search:
+
+```
+'dim containsIgnoreCase "some string"
+
+// which is equivalent to:
+'dim contains("some string", caseSensitive = false)
+```
+
+#### In
+
+To express the `SQL IN` operator, in order to match the value of a dimension into any value of a specified set of values.
+In the example below, the dimension `outlaw` matches to any of 'Good', 'Bad' or 'Ugly' values: 
+
+```
+'outlaw in ("Good", "Bad", "Ugly")
+```
+
+We can easily express a negation of the `in` operator, by directly using the `notIn` operator.
+
+```
+'outlaw notIn ("Good", "Bad", "Ugly")
+```
+
+#### Bound 
+
+Bound operator can be used to filter on ranges of dimension values. It can be used for comparison filtering like 
+greater than, less than, greater than or equal to, less than or equal to, and "between" (if both "lower" and 
+"upper" are set). For details see the examples below.
+
+When numbers are given to bound operators, then the ordering is numeric:
+
+```
+'dim > 10
+'dim >= 10.0
+'dim < 1.1
+'dim <= 1
+
+// 0.0 < dim < 10.0
+'dim between(0.0, 10.0) 
+
+// 0.0 <= dim <= 10.0
+'dim between(0.0, 10.0, lowerStrict = true, upperStrict = true)
+
+// 0.0 <= dim < 10.0
+'dim between(0.0, 10.0, lowerStrict = true, upperStrict = false)
+```
+
+When strings are given to bound operators, then the ordering is lexicographic:
+
+```
+'dim > "10"
+'dim >= "10.0"
+'dim < "1.1"
+'dim <= "1"
+
+// "0.0" < dim < "10.0"
+'dim between("0.0", "10.0")
+
+// "0.0" <= dim <= "10.0"
+'dim between("0.0", "10.0", lowerStrict = true, upperStrict = true)
+
+// "0.0" <= dim < "10.0"
+'dim between("0.0", "10.0", lowerStrict = true, upperStrict = false)
+```
+
+Furthermore, you can specify any other ordering (e.g. Alphanumeric) or define some extraction function:
+
+```
+'dim > "10" withOrdering(DimensionOrderType.Alphanumeric) 
+
+// "0.0" < dim < "10.0"
+'dim between("0.0", "10.0") withOrdering(DimensionOrderType.Alphanumeric) 
+```
+
+```
+'dim > "10" withOrdering(DimensionOrderType.Alphanumeric)
+
+// "0.0" < dim < "10.0"
+'dim between("0.0", "10.0") withOrdering(DimensionOrderType.Alphanumeric)
+
+// apply some extraction function
+'dim > "10" withExtractionFn(<some ExtractionFn>) 
+```
+
+#### Interval 
+
+Interval operator performs range filtering on dimensions that contain long millisecond values, 
+with the boundaries specified as ISO 8601 time intervals.
+ 
+```
+'dim interval "2011-06-01/2012-06-01" 
+
+'dim interval("2011-06-01/2012-06-01", "2012-06-01/2013-06-01", ...) 
+
+'__time interval "2011-06-01/2012-06-01"
+
+'__time interval("2011-06-01/2012-06-01", "2012-06-01/2013-06-01", ...)
+```
+
+#### Logical operators
+
+###### AND
+
+To define a logical `AND` between other operators you can use the operator `and`, for example:
+
+```
+('dim1 === 10) and ('dim2 interval "2011-06-01/2012-06-01") and ('dim3 === "foo")
+```
+
+Alternatively, you can use the function `conjunction`, as follows:
+
+```
+conjunction('dim1 === 10, 'dim2 interval "2011-06-01/2012-06-01", 'dim3 === "foo")
+```
+
+###### OR
+
+To define a logical `OR` between other operators you can use the operator `or`, for example:
+
+```
+('dim1 === 10) or ('dim2 interval "2011-06-01/2012-06-01") or ('dim3 === "foo")
+```
+
+Alternatively, you can use the function `disjunction`, as follows:
+
+```
+disjunction('dim1 === 10, 'dim2 interval "2011-06-01/2012-06-01", 'dim3 === "foo")
+```
+
+###### NOT
+
+To define a negation of an operator, you can use the operator `not`:
+
+```
+not('dim1 between (10, 100))
+```
+
+## Aggregations
+
+Aggregations are functions that summarize data. To add one or more aggregation functions in a DQL query you can 
+define aggregations as multiple arguments to the `agg` function of the builder, or alternatively call `agg` function 
+multiple times.
+
+```
+val query = DQL
+    .from("some_data_source_name")
+    .agg(aggregation0, aggregation1, aggregation2, ...)
+    ...
+    
+// or using multiple agg calls:
+val query = DQL
+    .from("some_data_source_name")
+    .agg(aggregation0) 
+    .agg(aggregation1)
+    .agg(aggregation2)
+    ...
+    
+// or a combination    
+val query = DQL
+    .from("some_data_source_name")
+    .agg(aggregation0, aggregation1)
+    .agg(aggregation2)
+    ...
+```
+
+The available aggregators are outlined below:
+
+#### Count aggregator
+
+`count` computes the count of Druid rows that match the filters.
+
+```
+count // uses the default name "count"
+
+count as "some_count" // uses the name "some_count"
+``` 
+
+#### Sum aggregators
+
+`longSum` and `doubleSum` computes the sum of values as a 64-bit signed integer or floating point value, respectively.
+
+```
+// can be defined over some dimension
+'dim_name.longSum as "agg_sum"
+
+// or as function
+doubleSum('dim_name) as "agg_sum"
+```
+
+#### Min / Max aggregators
+
+`longMin` and `doubleMin` computes the minimum of all metric values and Long.MAX_VALUE 
+or Double.POSITIVE_INFINITY, respectively.
+
+```
+// can be defined over some dimension
+'dim_name.longMin as "agg_min"
+
+// or as function
+doubleMin('dim_name) as "agg_min"
+```
+
+Similarly, `longMax` and `doubleMax` computes the maximum of all metric values and Long.MIN_VALUE 
+or Double.NEGATIVE_INFINITY, respectively.
+
+
+#### First / Last aggregator
+
+`longFirst` and `doubleFirst` computes the metric value with the minimum timestamp or 0 if no row exist. 
+`longLast` and `doubleLast` computes the metric value with the maximum timestamp or 0 if no row exist
+
+```
+// can be defined over some dimension
+'dim_name.longFirst as "agg_first"
+
+// or as function
+doubleLast('dim_name) as "agg_last"
+```
+
+#### Approximate Aggregations
+
+DQL supports `thetaSketch` and `hyperUnique` approximate aggregators.
+
+```
+// can be defined over some dimension
+'dim_name.thetaSketch as "agg_theta"
+
+// or as function
+hyperUnique('dim_name) as "agg_hyper_unique"
+
+// can also set additional parameters
+
+thetaSketch('dim_name).set(isInputThetaSketch = true, size = 32768) as "agg_theta"
+
+'dim_name.hyperUnique.set(isInputHyperUnique = true, isRound = true) as "agg_hyper_unique"
+```
+
+#### Filtered Aggregator
+
+
+`inFiltered` wraps any given aggregator, but only aggregates the values for which the given dimension the *in filter* matches
+Similarly, `selectorFiltered` wraps any given aggregator and filters the values using the *selector filter*.
+
+
+For example, the `inFiltered` below applies over the `longSum` aggregation, only for values 
+`#en.wikipedia` and `#de.wikipedia` of `channel` dimension:
+
+```
+'channel.inFiltered('count.longSum, "#en.wikipedia", "#de.wikipedia")
+
+// Equivalent inFiltered as function
+inFiltered('channel, 'count.longSum, "#en.wikipedia", "#de.wikipedia")
+``` 
+
+Similarly, the `selectorFiltered` below applies over the `longSum` aggregation, only for value `"#en.wikipedia"` of
+`channel` dimension:
+
+``` 
+'channel.selectorFiltered('count.longSum, "#en.wikipedia")
+
+// Equivalent selectorFiltered as function
+selectorFiltered('channel, 'count.longSum, "#en.wikipedia")
+
+``` 
+
+## Post-aggregations
+
+Post-aggregations are specifications of processing that should happen on aggregated values as they come out of Druid. 
+To add one or more post-aggregation functions in a DQL query you can define post-aggregation as multiple arguments to 
+the `postAgg` function of the builder, or alternatively call `postAgg` function  multiple times.
+
+```
+val query = DQL
+    .from("some_data_source_name")
+    .agg(...)
+    .postAgg(post-aggregation0, post-aggregation1, post-aggregation2, ...)
+    ...
+    
+// or using multiple postAgg calls:
+val query = DQL
+    .from("some_data_source_name")
+    .agg(...)
+    .postAgg(post-aggregation0) 
+    .postAgg(post-aggregation1)
+    .postAgg(post-aggregation2)
+    ...
+    
+// or a combination    
+val query = DQL
+    .from("some_data_source_name")
+    .agg(...)
+    .postAgg(post-aggregation0, post-aggregation1)
+    .postAgg(post-aggregation2)
+    ...
+```
+
+#### Arithmetic post-aggregator
+
+Arithmetic post-aggregator can be applied to aggregators or other post aggregators and 
+the supported functions are `+`, `-`, `*`, `/`, and `quotient`.
+
+```
+'dim_name + 2
+
+('count / 2) as "halfCount"
+```
+
+In arithmetic post-aggregators you can specify an ordering (e.g., NumericFirst) of the results (this can be useful 
+for topN queries). By default, Druid uses *floating point* ordering. You can explicitly set the ordering to be 
+either *floating point* or *numeric first*. The latter ordering always returns finite values first, followed 
+by *NaN*, and *infinite values* last.
+
+```
+import ing.wbaa.druid.definitions.Ordering
+
+// Set explicitly 'floating point' ordering:
+('count / 2).withOrdering(Ordering.FloatingPoint) as "halfCount"
+
+// or equivalently:
+('count / 2).floatingPointOrdering as "halfCount"
+
+// Set numeric first ordering:
+('count / 2).withOrdering(Ordering.NumericFirst) as "halfCount"
+
+// or equivalently:
+('count / 2).numericFirstOrdering as "halfCount"
+```
+
+#### HyperUnique Cardinality post-aggregator
+
+Is used to wrap a hyperUnique object such that it can be used in post aggregations.
+
+```
+'dim_name.hyperUniqueCardinality
+
+// or alternatively as function:
+hyperUniqueCardinality('dim_name)
+```
+
+
+## Extraction functions
+
+Extraction functions define the transformation applied to each dimension value.
+
+```
+import ing.wbaa.druid.LowerExtractionFn
+
+'countryName.extract(LowerExtractionFn()) as "country"
+
+// or as function
+extract('countryName, LowerExtractionFn()) as "country"
+```
+
+## Example queries
+
+#### Time-series query
+
+This is simplest form of query and takes all the common DQL parameters.
+
+For example, the following query is a time-series that counts the number of rows by hour:
+
+```
+case class TimeseriesCount(ts_count: Long)
+
+val query: TimeSeriesQuery = DQL
+    .from("wikiticker")
+    .granularity(GranularityType.Hour)
+    .interval("2011-06-01/2017-06-01")
+    .agg(count as "ts_count")
+    .build()
+
+val response: Future[List[GroupByIsAnonymous]] = query.execute().map(_.list[TimeseriesCount])
+```
+
+#### Top-N query
+
+The following query computes the Top-5 `countryName` with respect to the aggregation `agg_count`.
+
+```
+case class PostAggregationAnonymous(countryName: Option[String], agg_count: Double, half_count: Double)
+
+val query: TopNQuery = DQL
+    .from("wikiticker")
+    .granularity(GranularityType.Week)
+    .interval("2011-06-01/2017-06-01")
+    .agg(count as "agg_count")
+    .postAgg(('agg_count / 2) as "half_count")
+    .topN('countryName, metric = "agg_count", threshold = 5)
+    .build()
+
+val response: Future[List[PostAggregationAnonymous]] = query.execute().map(_.list[PostAggregationAnonymous])
+```
+
+#### Group-by query
+
+The following query performs group-by count over the dimension `isAnonymous`:
+
+```
+case class GroupByIsAnonymous(isAnonymous: String, count: Int)
+
+val query: GroupByQuery = DQL
+    .from("wikiticker")
+    .granularity(GranularityType.Day)
+    .interval("2011-06-01/2017-06-01")
+    .agg(count as "count")
+    .groupBy('isAnonymous)
+    .build()
+            
+val response: List[GroupByIsAnonymous] = query.execute().map(_.list[GroupByIsAnonymous])
+```
+
+A more advanced example of group-by count over the dimensions `isAnonymous` and `countryName`. 
+Here the `countryName` is being extracted to uppercase and the resulting dimension is named as `country`. 
+Furthermore, we are limiting the results to top-10 counts, therefore we define as numeric ordering 
+the aggregation `count`.
+
+```
+case class GroupByIsAnonymous(isAnonymous: String, country: Option[String], count: Int)
+
+val query: GroupByQuery = DQL
+    .from("wikiticker")
+    .granularity(GranularityType.Day)
+    .interval("2011-06-01/2017-06-01")
+    .agg(count as "count")
+    .groupBy('isAnonymous, 'countryName.extract(UpperExtractionFn()) as "country")
+    .limit(10, 'count.desc(DimensionOrderType.Numeric))
+    .build()
+    
+val response: Future[List[GroupByIsAnonymous]] = query.execute().map(_.list[GroupByIsAnonymous])
+```
+
+We can avoid null values in `country` by filtering the dimension `countryName`:
+
+```
+case class GroupByIsAnonymous(isAnonymous: String, country: String, count: Int)
+
+val query: GroupByQuery = DQL
+    .from("wikiticker")
+    .granularity(GranularityType.Day)
+    .interval("2011-06-01/2017-06-01")
+    .agg(count as "count")
+    .where('countryName.isNotNull)
+    .groupBy('isAnonymous, 'countryName.extract(UpperExtractionFn()) as "country")
+    .limit(10, 'count.desc(DimensionOrderType.Numeric))
+    .build()
+    
+val response: Future[List[GroupByIsAnonymous]] = query.execute().map(_.list[GroupByIsAnonymous])
+```
+
+We can also keep only those records that they are having count above 100 and below 200:
+
+```
+case class GroupByIsAnonymous(isAnonymous: String, country: String, count: Int)
+
+val query: GroupByQuery = DQL
+    .from("wikiticker")
+    .granularity(GranularityType.Day)
+    .interval("2011-06-01/2017-06-01")
+    .agg(count as "count")
+    .where('countryName.isNotNull)
+    .groupBy('isAnonymous, 'countryName.extract(UpperExtractionFn()) as "country")
+    .having('count > 100 and 'count < 200)
+    .limit(10, 'count.desc(DimensionOrderType.Numeric))
+    .build()
+      
+val response: Future[List[GroupByIsAnonymous]] = query.execute().map(_.list[GroupByIsAnonymous])
+```
+
+

--- a/src/main/scala/ing/wbaa/druid/DruidConfig.scala
+++ b/src/main/scala/ing/wbaa/druid/DruidConfig.scala
@@ -30,7 +30,17 @@ class DruidConfig(val host: String,
                   val secure: Boolean,
                   val url: String,
                   val datasource: String,
-                  val responseParsingTimeout: FiniteDuration)
+                  val responseParsingTimeout: FiniteDuration) {
+  def copy(
+      host: String = this.host,
+      port: Int = this.port,
+      secure: Boolean = this.secure,
+      url: String = this.url,
+      datasource: String = this.datasource,
+      responseParsingTimeout: FiniteDuration = this.responseParsingTimeout
+  ): DruidConfig =
+    new DruidConfig(host, port, secure, url, datasource, responseParsingTimeout)
+}
 
 object DruidConfig {
 

--- a/src/main/scala/ing/wbaa/druid/Enum.scala
+++ b/src/main/scala/ing/wbaa/druid/Enum.scala
@@ -61,6 +61,10 @@ trait UpperCaseEnumStringEncoder extends EnumStringEncoder { this: Enum =>
   def encode() = toString
 }
 
+trait LowerCaseEnumStringEncoder extends EnumStringEncoder { this: Enum =>
+  def encode() = toString.toLowerCase
+}
+
 trait CamelCaseEnumStringEncoder extends EnumStringEncoder { this: Enum =>
   private def decapitalize(input: String) = input.head.toLower + input.tail
   def encode()                            = decapitalize(toString)

--- a/src/main/scala/ing/wbaa/druid/definitions/Aggregation.scala
+++ b/src/main/scala/ing/wbaa/druid/definitions/Aggregation.scala
@@ -39,8 +39,8 @@ object AggregationType extends EnumCodec[AggregationType] {
   case object LongFirst   extends AggregationType
   case object LongLast    extends AggregationType
   case object ThetaSketch extends AggregationType
+  case object HyperUnique extends AggregationType
   case object Filtered    extends AggregationType
-
   val values: Set[AggregationType] = sealerate.values[AggregationType]
 }
 
@@ -78,6 +78,7 @@ object SingleFieldAggregation {
       case x: LongLastAggregation    => x.asJson
       case x: LongFirstAggregation   => x.asJson
       case x: ThetaSketchAggregation => x.asJson
+      case x: HyperUniqueAggregation => x.asJson
     }
   }
 }
@@ -119,6 +120,15 @@ case class ThetaSketchAggregation(name: String,
                                   size: Long = 16384)
     extends SingleFieldAggregation {
   val `type` = AggregationType.ThetaSketch
+}
+
+case class HyperUniqueAggregation(
+    name: String,
+    fieldName: String,
+    isInputHyperUnique: Boolean = false,
+    round: Boolean = false
+) extends SingleFieldAggregation {
+  val `type` = AggregationType.HyperUnique
 }
 
 trait FilteredAggregation extends Aggregation {

--- a/src/main/scala/ing/wbaa/druid/definitions/PostAggregation.scala
+++ b/src/main/scala/ing/wbaa/druid/definitions/PostAggregation.scala
@@ -153,19 +153,25 @@ case class JavascriptPostAggregation(
   override val `type` = PostAggregationType.Javascript
 }
 
+case class HyperUniqueCardinalityPostAggregation(name: String, fieldName: String)
+    extends PostAggregation {
+  override val `type` = PostAggregationType.HyperUniqueCardinality
+}
+
 object PostAggregation {
   implicit val encoder: Encoder[PostAggregation] = new Encoder[PostAggregation] {
     override def apply(pa: PostAggregation) =
       (pa match {
-        case x: ArithmeticPostAggregation            => x.asJsonObject
-        case x: FieldAccessPostAggregation           => x.asJsonObject
-        case x: FinalizingFieldAccessPostAggregation => x.asJsonObject
-        case x: ConstantPostAggregation              => x.asJsonObject
-        case x: DoubleGreatestPostAggregation        => x.asJsonObject
-        case x: LongGreatestPostAggregation          => x.asJsonObject
-        case x: DoubleLeastPostAggregation           => x.asJsonObject
-        case x: LongLeastPostAggregation             => x.asJsonObject
-        case x: JavascriptPostAggregation            => x.asJsonObject
+        case x: ArithmeticPostAggregation             => x.asJsonObject
+        case x: FieldAccessPostAggregation            => x.asJsonObject
+        case x: FinalizingFieldAccessPostAggregation  => x.asJsonObject
+        case x: ConstantPostAggregation               => x.asJsonObject
+        case x: DoubleGreatestPostAggregation         => x.asJsonObject
+        case x: LongGreatestPostAggregation           => x.asJsonObject
+        case x: DoubleLeastPostAggregation            => x.asJsonObject
+        case x: LongLeastPostAggregation              => x.asJsonObject
+        case x: JavascriptPostAggregation             => x.asJsonObject
+        case x: HyperUniqueCardinalityPostAggregation => x.asJsonObject
       }).add("type", pa.`type`.asJson).asJson
   }
 }

--- a/src/main/scala/ing/wbaa/druid/dql/DSL.scala
+++ b/src/main/scala/ing/wbaa/druid/dql/DSL.scala
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ing.wbaa.druid.dql
+
+import ing.wbaa.druid.definitions.ArithmeticFunction
+import ing.wbaa.druid.dql.expressions._
+
+import scala.language.implicitConversions
+
+object DSL
+    extends FilteringExpressionOps
+    with ExtractionFnOps
+    with AggregationOps
+    with PostAggregationOps {
+
+  /**
+    * @return a new instance of the QueryBuilder
+    */
+  def DQL: QueryBuilder = new QueryBuilder
+
+  /**
+    * Implicitly convert a Scala Symbol to an instance of Dim
+    */
+  implicit def symbolToDim(s: Symbol): Dim = new Dim(s.name)
+
+  implicit class StringToDim(val sc: StringContext) extends AnyVal {
+
+    /**
+      * Create a dim using simple string interpolator.
+      *
+      * {{{
+      *   val prefix = "foo"
+      *   val suffix = "bar"
+      *
+      *   d"${prefix}_${suffix}"
+      * }}}
+      *
+      * @param args The arguments to be inserted into the resulting string.
+      *
+      * @see StringContext
+      */
+    def d(args: Any*): Dim = Dim(sc.s(args: _*))
+  }
+
+  /**
+    * Create an instance of Dim
+    * @param name the name of the dimension
+    *
+    * @return the resulting Dim
+    */
+  def dim(name: String): Dim = Dim(name)
+
+  implicit class StringOps(val value: String) extends AnyVal {
+    def ===(s: Dim): FilteringExpression = s === value
+    def =!=(s: Dim): FilteringExpression = s =!= value
+  }
+
+  implicit class NumOps(val value: Double) extends AnyVal {
+
+    @inline
+    private def arithmeticPostAgg(s: Dim, fn: ArithmeticFunction): PostAggregationExpression =
+      ArithmeticPostAgg(
+        new ConstantPostAgg(value),
+        new FieldAccessPostAgg(s.name),
+        fn = fn
+      )
+
+    def ===(s: Dim): FilteringExpression = s === value
+    def =!=(s: Dim): FilteringExpression = s =!= value
+    def >(s: Dim): FilteringExpression   = s < value
+    def >=(s: Dim): FilteringExpression  = s =< value
+    def <(s: Dim): FilteringExpression   = s > value
+    def =<(s: Dim): FilteringExpression  = s >= value
+
+    def +(s: Symbol): PostAggregationExpression = arithmeticPostAgg(s, ArithmeticFunction.PLUS)
+    def -(s: Symbol): PostAggregationExpression = arithmeticPostAgg(s, ArithmeticFunction.MINUS)
+    def *(s: Symbol): PostAggregationExpression = arithmeticPostAgg(s, ArithmeticFunction.MULT)
+    def /(s: Symbol): PostAggregationExpression = arithmeticPostAgg(s, ArithmeticFunction.DIV)
+    def quotient(s: Symbol): PostAggregationExpression =
+      arithmeticPostAgg(s, ArithmeticFunction.QUOT)
+
+  }
+}

--- a/src/main/scala/ing/wbaa/druid/dql/Dim.scala
+++ b/src/main/scala/ing/wbaa/druid/dql/Dim.scala
@@ -1,0 +1,581 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreement  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ing.wbaa.druid.dql
+
+import ing.wbaa.druid.definitions._
+import ing.wbaa.druid.dql.Dim.DimType
+import ing.wbaa.druid.dql.expressions._
+import ing.wbaa.druid.{ DimensionOrder, DimensionOrderType, Direction, OrderByColumnSpec }
+
+/**
+  * This class represents a single dimension in a Druid datasource, along with all operations that can be
+  * performed in a query (e.g., filtering, aggregation, post-aggregation, etc.).
+  *
+  * @param name The name of the dimension
+  * @param outputNameOpt The output name of the result (e.g., the name after a aggregation operation)
+  * @param outputTypeOpt The resulting output type
+  * @param extractionFnOpt An extraction function to apply in this dimension
+  */
+case class Dim private[dql] (name: String,
+                             outputNameOpt: Option[String] = None,
+                             outputTypeOpt: Option[String] = None,
+                             extractionFnOpt: Option[ExtractionFn] = None)
+    extends Named[Dim] {
+
+  /**
+    * Sets an alias of the dimension
+    *
+    * @return the resulting dimension with the given name
+    */
+  override def alias(name: String): Dim = copy(outputNameOpt = Option(name))
+
+  /**
+    * @return the name of the dimension
+    */
+  override def getName: String = name
+
+  /**
+    * Set the output type of the dimension.
+    * In can be any of `STRING`, `LONG` or `FLOAT`.
+    *
+    * @param outputType the output type (`STRING`, `LONG` or `FLOAT`.)
+    * @return the dimension having set the specified output type
+    */
+  def cast(outputType: String): Dim = {
+    val uppercase = outputType.toUpperCase
+    require(Dim.ValidTypes.contains(uppercase))
+    copy(outputTypeOpt = Option(uppercase))
+  }
+
+  def cast(outputType: Dim.DimType): Dim =
+    copy(outputTypeOpt = Option(outputType.toString))
+
+  /**
+    * @return this dimension with FLOAT as output type
+    */
+  def asFloat: Dim = cast(DimType.FLOAT)
+
+  /**
+    * @return this dimension with LONG as output type
+    */
+  def asLong: Dim = cast(DimType.LONG)
+
+  /**
+    * @return this dimension with STRING as output type
+    */
+  def asString: Dim = cast(DimType.STRING)
+
+  /**
+    * Set an extraction function
+    * @param fn the extraction function to use (see [[ExtractionFn]])
+    * @return
+    */
+  def extract(fn: ExtractionFn): Dim =
+    copy(extractionFnOpt = Option(fn))
+
+  /**
+    * @return the resulting instance of Dimension. When `extractionFn` is set,
+    *         then give an instance of ExtractionDimension, otherwise DefaultDimension.
+    */
+  protected[dql] def build(): Dimension =
+    extractionFnOpt match {
+      case Some(extractionFn) =>
+        ExtractionDimension(name, outputNameOpt.orElse(Option(name)), outputTypeOpt, extractionFn)
+
+      case None =>
+        DefaultDimension(name, outputNameOpt.orElse(Option(name)), outputTypeOpt)
+    }
+
+  // --------------------------------------------------------------------------
+  // --- Functions for creating filtering expressions
+  // --------------------------------------------------------------------------
+
+  @inline
+  private def eqVal(value: String): FilteringExpression = new EqString(this, value)
+
+  @inline
+  private def eqNum(value: Double): FilteringExpression = new EqDouble(this, value)
+
+  @inline
+  private def compareWith(other: Dim): FilteringExpression =
+    new ColumnComparison(this :: other :: Nil)
+
+  /**
+    * @return column-comparison filtering expression between this and the specified dimensions.
+    */
+  def ===(other: Dim): FilteringExpression = compareWith(other)
+
+  /**
+    * @return a filtering expression of value equals (string)
+    */
+  def ===(value: String): FilteringExpression = eqVal(value)
+
+  /**
+    * @return a filtering expression of value equals (numeric)
+    */
+  def ===(value: Double): FilteringExpression = eqNum(value)
+
+  /**
+    * @return negated column-comparison filtering expression between this and the specified dimensions.
+    */
+  def =!=(other: Dim): FilteringExpression = FilteringExpressionOps.not(compareWith(other))
+
+  /**
+    * @return a filtering expression of not equals (string)
+    */
+  def =!=(value: String): FilteringExpression = FilteringExpressionOps.not(eqVal(value))
+
+  /**
+    * @return a filtering expression of not equals (numeric)
+    */
+  def =!=(value: Double): FilteringExpression = FilteringExpressionOps.not(eqNum(value))
+
+  /**
+    * @return in-filter of this dimension for the specified values
+    */
+  def in(value: String, values: String*): FilteringExpression = new In(this, value :: values.toList)
+
+  /**
+    * @return negated in-filter of this dimension for the specified values
+    */
+  def notIn(value: String, values: String*): FilteringExpression =
+    FilteringExpressionOps.not(new In(this, value :: values.toList))
+
+  /**
+    * @return like-filter of this dimension for the specified LIKE pattern
+    */
+  def like(pattern: String): FilteringExpression = new Like(this, pattern)
+
+  /**
+    * @return regex-filter of this dimension for the specified Java regular expression pattern
+    */
+  def regex(pattern: String): FilteringExpression = new Regex(this, pattern)
+
+  /**
+    * @return selector expression stating that the contents of the dimension should be null
+    */
+  def isNull: FilteringExpression = new NullDim(this)
+
+  /**
+    * @return selector expression stating that the contents of the dimension should not be null
+    */
+  def isNotNull: FilteringExpression = FilteringExpressionOps.not(this.isNull)
+
+  /**
+    * Filter based on a lower bound of dimension values, using numeric ordering.
+    *
+    * @return a bound filtering expression, with numeric ordering, specifying that the value of
+    *         the dimension should be greater than the given number.
+    */
+  def >(value: Double): FilteringExpression = new Gt(this, value)
+
+  /**
+    * Filter based on a strict lower bound of dimension values, using numeric ordering.
+    *
+    * @return a bound filtering expression, with numeric ordering, specifying that the value of
+    *         the dimension should be greater than, or equal to the given number.
+    */
+  def >=(value: Double): FilteringExpression = new GtEq(this, value)
+
+  /**
+    * Filter based on a upper bound of dimension values, using numeric ordering.
+    *
+    * @return a bound filtering expression, with numeric ordering, specifying that the value of
+    *         the dimension should be less than the given number.
+    */
+  def <(value: Double): FilteringExpression = new Lt(this, value)
+
+  /**
+    * Filter based on a strict upper bound of dimension values, using numeric ordering.
+    *
+    * @return a bound filtering expression, with numeric ordering, specifying that the value of
+    *         the dimension should be less than, or equal to the given number.
+    */
+  def =<(value: Double): FilteringExpression = new LtEq(this, value)
+
+  /**
+    * Filter on ranges of dimension values, using numeric ordering.
+    *
+    * @param lower the lower bound
+    * @param upper the upper bound
+    * @param lowerStrict Perform strict comparison on the lower bound ("<" instead of "<=")
+    * @param upperStrict Perform strict comparison on the upper bound (">" instead of ">=")
+    *
+    * @return a bound filtering expression, with numeric ordering
+    */
+  def between(lower: Double, upper: Double, lowerStrict: Boolean, upperStrict: Boolean): Bound =
+    Bound(
+      dimension = name,
+      lower = Option(lower.toString),
+      lowerStrict = Option(lowerStrict),
+      upper = Option(upper.toString),
+      upperStrict = Option(upperStrict),
+      ordering = Option(DimensionOrderType.Numeric)
+    )
+
+  /**
+    * Filter on ranges of dimension values, using numeric ordering, where lower and upper bounds are non-strict.
+    *
+    * @param lower the lower bound
+    * @param upper the upper bound
+    *
+    * @return a bound filtering expression, with numeric ordering, where each bound is not-strict
+    */
+  def between(lower: Double, upper: Double): Bound =
+    between(lower, upper, lowerStrict = false, upperStrict = false)
+
+  /**
+    * Filter based on a lower bound of dimension values, using lexicographic ordering.
+    *
+    * @return a bound filtering expression, with lexicographic ordering, specifying that the value of
+    *         the dimension should be greater than the given number.
+    */
+  def >(value: String): Bound =
+    Bound(dimension = name,
+          lower = Option(value),
+          upper = None,
+          ordering = Option(DimensionOrderType.Lexicographic))
+
+  /**
+    * Filter based on a strict lower bound of dimension values, using lexicographic ordering.
+    *
+    * @return a bound filtering expression, with lexicographic ordering, specifying that the value of
+    *         the dimension should be greater than, or equal to the given number.
+    */
+  def >=(value: String): Bound =
+    Bound(dimension = name,
+          lower = Option(value),
+          lowerStrict = Some(true),
+          upper = None,
+          ordering = Option(DimensionOrderType.Lexicographic))
+
+  /**
+    * Filter based on a upper bound of dimension values, using lexicographic ordering.
+    *
+    * @return a bound filtering expression, with lexicographic ordering, specifying that the value of
+    *         the dimension should be less than the given number.
+    */
+  def <(value: String): Bound =
+    Bound(dimension = name,
+          lower = None,
+          upper = Option(value),
+          ordering = Option(DimensionOrderType.Lexicographic))
+
+  /**
+    * Filter based on a strict upper bound of dimension values, using lexicographic ordering.
+    *
+    * @return a bound filtering expression, with lexicographic ordering, specifying that the value of
+    *         the dimension should be less than, or equal to the given number.
+    */
+  def =<(value: String): Bound =
+    Bound(dimension = name,
+          lower = None,
+          upper = Option(value),
+          upperStrict = Some(true),
+          ordering = Option(DimensionOrderType.Lexicographic))
+
+  /**
+    * Filter on ranges of dimension values, using lexicographic ordering.
+    *
+    * @param lower the lower bound
+    * @param upper the upper bound
+    * @param lowerStrict Perform strict comparison on the lower bound ("<" instead of "<=")
+    * @param upperStrict Perform strict comparison on the upper bound (">" instead of ">=")
+    *
+    * @return a bound filtering expression, with lexicographic ordering
+    */
+  def between(lower: String, upper: String, lowerStrict: Boolean, upperStrict: Boolean): Bound =
+    Bound(
+      dimension = name,
+      lower = Option(lower),
+      lowerStrict = Option(lowerStrict),
+      upper = Option(upper),
+      upperStrict = Option(upperStrict),
+      ordering = Option(DimensionOrderType.Lexicographic)
+    )
+
+  /**
+    * Filter on ranges of dimension values, using lexicographic ordering, where lower and upper bounds are non-strict.
+    *
+    * @param lower the lower bound
+    * @param upper the upper bound
+    *
+    * @return a bound filtering expression, with lexicographic ordering, where each bound is not-strict
+    */
+  def between(lower: String, upper: String): Bound =
+    between(lower, upper, lowerStrict = false, upperStrict = false)
+
+  /**
+    * Performs range filtering on columns that contain long millisecond values,
+    * the boundary specified as ISO 8601 time interval
+    *
+    * @return the interval filtering expression
+    */
+  def interval(value: String): FilteringExpression = new Interval(this, value :: Nil)
+
+  /**
+    * Performs range filtering on columns that contain long millisecond values,
+    * the boundaries specified as ISO 8601 time intervals
+    *
+    * @return the interval filtering expression
+    */
+  def intervals(first: String, second: String, rest: String*): FilteringExpression =
+    new Interval(this, first :: second :: rest.toList)
+
+  /**
+    * Filter on partial string matches
+    *
+    * @param value the value to search
+    * @param caseSensitive enable/disable case-sensitive search
+    *
+    * @return the search filtering expression
+    */
+  def contains(value: String, caseSensitive: Boolean = true): FilteringExpression =
+    new Contains(this, value, caseSensitive)
+
+  /**
+    * Filter on partial string matches, with ignore case search
+    *
+    * @return the search filtering expression
+    */
+  def containsIgnoreCase(value: String): FilteringExpression =
+    new Contains(this, value, caseSensitive = false)
+
+  /**
+    * Filter on partial string matches, with ignore case search
+    *
+    * @return the search filtering expression
+    */
+  def containsInsensitive(value: String): FilteringExpression =
+    new InsensitiveContains(this, value)
+
+  // --------------------------------------------------------------------------
+  // --- Functions for creating OrderByColumnSpec
+  // --------------------------------------------------------------------------
+
+  /**
+    * Set column ascending direction, using lexicographic ordering
+    */
+  def asc: OrderByColumnSpec =
+    OrderByColumnSpec(dimension = this.name, direction = Direction.Ascending)
+
+  /**
+    * Set column descending direction, using lexicographic ordering
+    */
+  def desc: OrderByColumnSpec =
+    OrderByColumnSpec(dimension = this.name, direction = Direction.Descending)
+
+  /**
+    * Set column ascending direction, using the specified ordering
+    */
+  def asc(orderType: DimensionOrderType): OrderByColumnSpec =
+    OrderByColumnSpec(
+      dimension = this.name,
+      direction = Direction.Ascending,
+      dimensionOrder = DimensionOrder(orderType)
+    )
+
+  /**
+    * Set column descending direction, using the specified ordering
+    */
+  def desc(orderType: DimensionOrderType): OrderByColumnSpec =
+    OrderByColumnSpec(
+      dimension = this.name,
+      direction = Direction.Descending,
+      dimensionOrder = DimensionOrder(orderType)
+    )
+
+  // --------------------------------------------------------------------------
+  // --- Functions for creating aggregation expressions
+  // --------------------------------------------------------------------------
+
+  /**
+    * Aggregation to compute the sum of values (as a 64-bit signed integer)
+    */
+  def longSum: AggregationExpression = AggregationOps.longSum(this)
+
+  /**
+    * Aggregation to compute the maximum of all metric values and Long.MAX_VALUE
+    */
+  def longMax: AggregationExpression = AggregationOps.longMax(this)
+
+  /**
+    * Aggregation to compute the minimum of all metric values and Long.MIN_VALUE
+    */
+  def longMin: AggregationExpression = AggregationOps.longMin(this)
+
+  /**
+    * Aggregation to compute the metric value with the minimum timestamp or 0 if no row exist
+    */
+  def longFirst: AggregationExpression = AggregationOps.longFirst(this)
+
+  /**
+    * Aggregation to compute the metric value with the maximum timestamp or 0 if no row exist
+    */
+  def longLast: AggregationExpression = AggregationOps.longLast(this)
+
+  /**
+    * Aggregation to compute the sum of values (as a 64-bit floating point value)
+    */
+  def doubleSum: AggregationExpression = AggregationOps.doubleSum(this)
+
+  /**
+    * Aggregation to compute the maximum of all metric values and Double.NEGATIVE_INFINITY
+    */
+  def doubleMax: AggregationExpression = AggregationOps.doubleMax(this)
+
+  /**
+    * Aggregation to compute the minimum of all metric values and Double.POSITIVE_INFINITY
+    */
+  def doubleMin: AggregationExpression = AggregationOps.doubleMin(this)
+
+  /**
+    * Aggregation to compute the metric value with the minimum timestamp or 0 if no row exist
+    */
+  def doubleFirst: AggregationExpression = AggregationOps.doubleFirst(this)
+
+  /**
+    * Aggregation to compute the metric value with the maximum timestamp or 0 if no row exist
+    */
+  def doubleLast: AggregationExpression = AggregationOps.doubleLast(this)
+
+  /**
+    * Aggregation to compute theta-sketches
+    */
+  def thetaSketch: ThetaSketchAgg = AggregationOps.thetaSketch(this)
+
+  /**
+    * Aggregation to compute the estimated cardinality of a dimension that
+    * has been aggregated as a "hyperUnique" metric at indexing time.
+    */
+  def hyperUnique: HyperUniqueAgg = AggregationOps.hyperUnique(this)
+
+  /**
+    * Wraps any given aggregator, but only aggregates the values
+    * for which the given dimension filter matches, by using the in filter.
+    *
+    * @param aggregator the aggregator to wrap
+    * @param values the values to filter
+    */
+  def inFiltered(aggregator: AggregationExpression, values: String*): AggregationExpression =
+    AggregationOps.inFiltered(this, aggregator, values: _*)
+
+  /**
+    * Wraps any given aggregator
+    *
+    * @param aggregator the aggregator to wrap
+    */
+  def selectorFiltered(aggregator: AggregationExpression): SelectorFilteredAgg =
+    AggregationOps.selectorFiltered(this, aggregator)
+
+  /**
+    * Wraps any given aggregator, but only aggregates the values
+    * for which the given dimension filter matches, by using the selector filter.
+    *
+    * @param aggregator the aggregator to wrap
+    * @param value the values to select
+    */
+  def selectorFiltered(aggregator: AggregationExpression, value: String): SelectorFilteredAgg =
+    AggregationOps.selectorFiltered(this, aggregator, value)
+
+  // --------------------------------------------------------------------------
+  // --- Functions for creating post-aggregation expressions
+  // --------------------------------------------------------------------------
+
+  @inline
+  private def arithmeticAgg(value: Double, fn: ArithmeticFunction): ArithmeticPostAgg =
+    ArithmeticPostAgg(leftField = new FieldAccessPostAgg(this.name),
+                      rightField = new ConstantPostAgg(value),
+                      fn = fn)
+  @inline
+  private def arithmeticFieldAgg(right: Dim, fn: ArithmeticFunction): ArithmeticPostAgg =
+    ArithmeticPostAgg(leftField = new FieldAccessPostAgg(this.name),
+                      rightField = new FieldAccessPostAgg(right.name),
+                      fn = fn)
+
+  /**
+    * Arithmetic addition post-aggregator
+    */
+  def +(v: Double): ArithmeticPostAgg = arithmeticAgg(v, ArithmeticFunction.PLUS)
+
+  /**
+    * Arithmetic subtraction post-aggregator
+    */
+  def -(v: Double): ArithmeticPostAgg = arithmeticAgg(v, ArithmeticFunction.MINUS)
+
+  /**
+    * Arithmetic multiplication post-aggregator
+    */
+  def *(v: Double): ArithmeticPostAgg = arithmeticAgg(v, ArithmeticFunction.MULT)
+
+  /**
+    * Arithmetic division post-aggregator, that always returns 0 when dividing by 0,
+    * regardless of the numerator
+    */
+  def /(v: Double): ArithmeticPostAgg = arithmeticAgg(v, ArithmeticFunction.DIV)
+
+  /**
+    * Arithmetic division post-aggregator
+    */
+  def quotient(v: Double): ArithmeticPostAgg = arithmeticAgg(v, ArithmeticFunction.QUOT)
+
+  /**
+    * Arithmetic addition post-aggregator
+    */
+  def +(v: Dim): ArithmeticPostAgg = arithmeticFieldAgg(v, ArithmeticFunction.PLUS)
+
+  /**
+    * Arithmetic subtraction post-aggregator
+    */
+  def -(v: Dim): ArithmeticPostAgg = arithmeticFieldAgg(v, ArithmeticFunction.MINUS)
+
+  /**
+    * Arithmetic multiplication post-aggregator
+    */
+  def *(v: Dim): ArithmeticPostAgg = arithmeticFieldAgg(v, ArithmeticFunction.MULT)
+
+  /**
+    * Arithmetic division post-aggregator, that always returns 0 when dividing by 0,
+    * regardless of the numerator
+    */
+  def /(v: Dim): ArithmeticPostAgg = arithmeticFieldAgg(v, ArithmeticFunction.DIV)
+
+  /**
+    * Arithmetic division post-aggregator
+    */
+  def quotient(v: Dim): ArithmeticPostAgg = arithmeticFieldAgg(v, ArithmeticFunction.QUOT)
+
+  /**
+    * HyperUnique Cardinality post-aggregator
+    */
+  def hyperUniqueCardinality: HyperUniqueCardinalityPostAgg =
+    HyperUniqueCardinalityPostAgg(this.name)
+}
+
+object Dim {
+
+  final val ValidTypes = Set("STRING", "LONG", "FLOAT")
+
+  type DimType = DimType.Value
+
+  object DimType extends Enumeration {
+    val STRING: DimType = Value(0, "STRING")
+    val LONG: DimType   = Value(1, "LONG")
+    val FLOAT: DimType  = Value(2, "FLOAT")
+  }
+}

--- a/src/main/scala/ing/wbaa/druid/dql/Operators.scala
+++ b/src/main/scala/ing/wbaa/druid/dql/Operators.scala
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ing.wbaa.druid.dql
+
+import ing.wbaa.druid.definitions.{ ExtractionFn, Filter }
+import ing.wbaa.druid.dql.expressions._
+
+trait AggregationOps {
+
+  def longSum(dimName: String): LongSumAgg = new LongSumAgg(dimName)
+  def longSum(dim: Dim): LongSumAgg        = longSum(dim.name)
+
+  def longMax(dimName: String): LongMaxAgg = new LongMaxAgg(dimName)
+  def longMax(dim: Dim): LongMaxAgg        = longMax(dim.name)
+
+  def longMin(dimName: String): LongMinAgg = new LongMinAgg(dimName)
+  def longMin(dim: Dim): LongMinAgg        = longMin(dim.name)
+
+  def longFirst(dimName: String): LongFirstAgg = new LongFirstAgg(dimName)
+  def longFirst(dim: Dim): LongFirstAgg        = longFirst(dim.name)
+
+  def longLast(dimName: String): LongLastAgg = new LongLastAgg(dimName)
+  def longLast(dim: Dim): LongLastAgg        = longLast(dim.name)
+
+  def doubleSum(dimName: String): DoubleSumAgg = new DoubleSumAgg(dimName)
+  def doubleSum(dim: Dim): DoubleSumAgg        = doubleSum(dim.name)
+
+  def doubleMax(dimName: String): DoubleMaxAgg = new DoubleMaxAgg(dimName)
+  def doubleMax(dim: Dim): DoubleMaxAgg        = doubleMax(dim.name)
+
+  def doubleMin(dimName: String): DoubleMinAgg = new DoubleMinAgg(dimName)
+  def doubleMin(dim: Dim): DoubleMinAgg        = doubleMin(dim.name)
+
+  def doubleFirst(dimName: String): DoubleFirstAgg = new DoubleFirstAgg(dimName)
+  def doubleFirst(dim: Dim): DoubleFirstAgg        = doubleFirst(dim.name)
+
+  def doubleLast(dimName: String): DoubleLastAgg = new DoubleLastAgg(dimName)
+  def doubleLast(dim: Dim): DoubleLastAgg        = doubleLast(dim.name)
+
+  def thetaSketch(dimName: String): ThetaSketchAgg = ThetaSketchAgg(dimName)
+  def thetaSketch(dim: Dim): ThetaSketchAgg        = thetaSketch(dim.name)
+
+  def hyperUnique(dimName: String): HyperUniqueAgg = HyperUniqueAgg(dimName)
+
+  def hyperUnique(dim: Dim): HyperUniqueAgg = hyperUnique(dim.name)
+
+  def inFiltered(dimName: String,
+                 aggregator: AggregationExpression,
+                 values: String*): InFilteredAgg =
+    InFilteredAgg(dimName, values, aggregator.build())
+
+  def inFiltered(dim: Dim, aggregator: AggregationExpression, values: String*): InFilteredAgg =
+    inFiltered(dim.name, aggregator, values: _*)
+
+  def selectorFiltered(dimName: String,
+                       aggregator: AggregationExpression,
+                       value: String): SelectorFilteredAgg =
+    SelectorFilteredAgg(dimName, Option(value), aggregator.build())
+
+  def selectorFiltered(dim: Dim,
+                       aggregator: AggregationExpression,
+                       value: String): SelectorFilteredAgg =
+    selectorFiltered(dim.name, aggregator, value)
+
+  def selectorFiltered(dimName: String, aggregator: AggregationExpression): SelectorFilteredAgg =
+    SelectorFilteredAgg(dimName, None, aggregator.build())
+
+  def selectorFiltered(dim: Dim, aggregator: AggregationExpression): SelectorFilteredAgg =
+    SelectorFilteredAgg(dim.name, None, aggregator.build())
+
+  def count: CountAgg = new CountAgg()
+}
+
+trait FilteringExpressionOps {
+
+  def not(op: FilteringExpression): FilteringExpression = op match {
+    case neg: Not => neg.op
+    case _        => new Not(op)
+  }
+
+  def disjunction(others: FilteringExpression*): FilteringExpression = new Or(others.toList)
+
+  def conjunction(others: FilteringExpression*): FilteringExpression = new And(others.toList)
+
+  def filter(value: FilteringExpression): FilteringExpression = new FilterOnlyOperator {
+    override protected[dql] def createFilter: Filter = value.createFilter
+  }
+}
+
+trait ExtractionFnOps {
+  def extract(dim: Dim, fn: ExtractionFn): Dim        = dim.extract(fn)
+  def extract(dimName: String, fn: ExtractionFn): Dim = Dim(dimName, extractionFnOpt = Option(fn))
+  def extract(dim: Symbol, fn: ExtractionFn): Dim     = Dim(dim.name, extractionFnOpt = Option(fn))
+}
+
+trait PostAggregationOps {
+  def hyperUniqueCardinality(fieldName: String): PostAggregationExpression =
+    HyperUniqueCardinalityPostAgg(fieldName)
+
+  def hyperUniqueCardinality(dim: Dim): PostAggregationExpression =
+    HyperUniqueCardinalityPostAgg(dim.name, dim.outputNameOpt)
+}
+
+object AggregationOps         extends AggregationOps
+object FilteringExpressionOps extends FilteringExpressionOps
+object ExtractionFnOps        extends ExtractionFnOps
+object PostAggregationOps     extends PostAggregationOps

--- a/src/main/scala/ing/wbaa/druid/dql/QueryBuilder.scala
+++ b/src/main/scala/ing/wbaa/druid/dql/QueryBuilder.scala
@@ -1,0 +1,330 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ing.wbaa.druid.dql
+
+import ing.wbaa.druid._
+import ing.wbaa.druid.definitions._
+import ing.wbaa.druid.dql.expressions._
+
+/**
+  * Collection of common functions for all query builders
+  */
+private[dql] sealed trait QueryBuilderCommons {
+
+  protected var dataSourceOpt                   = Option.empty[String]
+  protected var granularityOpt                  = Option.empty[Granularity]
+  protected var aggregations: List[Aggregation] = Nil
+
+  protected var complexAggregationNames: Set[String] = Set.empty[String]
+
+  protected var intervals: List[String] = Nil
+
+  protected var filters: List[Filter] = Nil
+
+  protected var postAggregationExpr: List[PostAggregationExpression] = Nil
+
+  /**
+    * Specify the datasource to use, other than the default one in the configuration
+    */
+  def from(dataSource: String): this.type = {
+    dataSourceOpt = Option(dataSource)
+    this
+  }
+
+  /**
+    * Define the granularity to bucket query results
+    */
+  def granularity(granularity: Granularity): this.type = {
+    granularityOpt = Option(granularity)
+    this
+  }
+
+  /**
+    * Specify one or more aggregations to use
+    */
+  def agg(aggs: AggregationExpression*): this.type = {
+
+    complexAggregationNames ++= aggs.filter(_.isComplex).map(_.getName)
+    aggregations = aggs.foldRight(aggregations)((agg, acc) => agg.build() :: acc)
+
+    this
+  }
+
+  /**
+    * Specify one or more post-aggregations to use
+    */
+  def postAgg(postAggs: PostAggregationExpression*): this.type = {
+    postAggregationExpr = postAggs.foldRight(postAggregationExpr)((agg, acc) => agg :: acc)
+    this
+  }
+
+  /**
+    * Specify the time range to run the query over (should be expressed as ISO-8601 interval)
+    */
+  def interval(interval: String): this.type = {
+    intervals = interval :: intervals
+    this
+  }
+
+  /**
+    * Specify multiple time ranges to run the query over (should be expressed as ISO-8601 intervals)
+    */
+  def intervals(ints: String*): this.type = {
+    intervals ++= ints.toList
+    this
+  }
+
+  /**
+    * Specify one or more filter operations to use in the query
+    */
+  def where(filter: FilteringExpression): this.type = {
+
+    filters = filter.asFilter :: filters
+    this
+  }
+
+  protected def getFilters: Option[Filter] =
+    if (filters.isEmpty) None
+    else if (filters.size == 1) Option(filters.head)
+    else Option(AndFilter(filters))
+
+  protected def copyTo[T <: QueryBuilderCommons](other: T): T = {
+    other.dataSourceOpt = dataSourceOpt
+    other.granularityOpt = granularityOpt
+    other.aggregations = aggregations
+    other.complexAggregationNames = complexAggregationNames
+    other.intervals = intervals
+    other.filters = filters
+    other.postAggregationExpr = postAggregationExpr
+    other
+  }
+
+  protected def getPostAggs: List[PostAggregation] =
+    postAggregationExpr.map(expr => expr.build(complexAggregationNames))
+
+}
+
+/**
+  * This is the default query build, in order to create Timeseries queries
+  */
+final class QueryBuilder private[dql] () extends QueryBuilderCommons {
+
+  // Default is false (ascending)
+  private var descending = false
+
+  /**
+    * Define whether to make descending ordered result
+    */
+  def setDescending(v: Boolean): this.type = {
+    descending = v
+    this
+  }
+
+  /**
+    * Gives the resulting time-series query, wrt. the given query parameters (e.g., where, datasource, etc.)
+    *
+    * @return the resulting time-series query
+    */
+  def build()(implicit druidConfig: DruidConfig = DruidConfig.DefaultConfig): TimeSeriesQuery = {
+
+    val conf = dataSourceOpt
+      .map(ds => druidConfig.copy(datasource = ds))
+      .getOrElse(druidConfig)
+
+    TimeSeriesQuery(
+      aggregations = this.aggregations,
+      intervals = this.intervals,
+      filter = this.getFilters,
+      granularity = this.granularityOpt.getOrElse(GranularityType.Week),
+      descending = this.descending.toString,
+      postAggregations = this.getPostAggs
+    )(conf)
+  }
+
+  /**
+    * Define that the query will be a top-n query
+    *
+    * @param dimension the dimension that you want the top taken for
+    * @param metric the metric to sort by for the top list
+    * @param threshold an integer defining the N in the top-n
+    *
+    * @return the builder for top-n queries
+    */
+  def topN(dimension: Dim, metric: String, threshold: Int): TopNQueryBuilder =
+    copyTo(new TopNQueryBuilder(dimension, metric, threshold))
+
+  /**
+    * Define that the query will be a group-by query
+    * @param dimensions the dimensions to perform a group-by query
+    * @return the builder for group-by queries
+    */
+  def groupBy(dimensions: Dim*): GroupByQueryBuilder =
+    copyTo(new GroupByQueryBuilder(dimensions))
+
+}
+
+/**
+  * Builder for top-n queries
+  *
+  * @param dimension the dimension that you want the top taken for
+  * @param metric the metric to sort by for the top list
+  * @param n an integer defining the N in the top-n
+  */
+final class TopNQueryBuilder private[dql] (dimension: Dim, metric: String, n: Int)
+    extends QueryBuilderCommons {
+
+  // Default is true (descending)
+  protected var isDescending = true
+
+  /**
+    * Define whether to make descending ordered result
+    */
+  def setDescending(v: Boolean): this.type = {
+    isDescending = v
+    this
+  }
+
+  /**
+    * Gives the resulting top-n query, wrt. the given query parameters (e.g., where, datasource, etc.)
+    *
+    * @return the resulting top-n query
+    */
+  def build()(implicit druidConfig: DruidConfig = DruidConfig.DefaultConfig): TopNQuery = {
+
+    val conf = dataSourceOpt
+      .map(ds => druidConfig.copy(datasource = ds))
+      .getOrElse(druidConfig)
+
+    TopNQuery(
+      dimension = this.dimension.build(),
+      threshold = n,
+      metric = metric,
+      aggregations = this.aggregations,
+      intervals = this.intervals,
+      granularity = this.granularityOpt.getOrElse(GranularityType.All),
+      filter = this.getFilters,
+      postAggregations = this.getPostAggs
+    )(conf)
+  }
+
+}
+
+/**
+  * Builder for group-by queries
+  *
+  * @param dimensions the dimensions to perform a group-by query
+  */
+final class GroupByQueryBuilder private[dql] (dimensions: Seq[Dim]) extends QueryBuilderCommons {
+
+  protected var limitOpt                        = Option.empty[Int]
+  protected var limitCols                       = Seq.empty[OrderByColumnSpec]
+  protected var havingExpressions: List[Having] = Nil
+
+  protected var excludeNullsOpt = Option.empty[Boolean]
+
+  /**
+    * Specify which rows from a group-by query should be returned, by specifying conditions on aggregated values
+    */
+  def having(conditions: FilteringExpression): this.type = {
+    havingExpressions = conditions.asHaving :: havingExpressions
+    this
+  }
+
+  /**
+    * Sort and limit the set of results of the group-by query
+    *
+    * @param n the upper limit of the number of results
+    * @param direction specify the order of the results (i.e., ascending or descending) for all group-by dimensions
+    * @param dimensionOrderType specify the type of the ordering (lexicographic, alphanumeric, etc.)
+    *                           for all group-by dimensions. Default is lexicographic.
+    */
+  def limit(
+      n: Int,
+      direction: Direction,
+      dimensionOrderType: DimensionOrderType = DimensionOrderType.Lexicographic
+  ): this.type = {
+    limitOpt = Option(n)
+    limitCols = dimensions.map(
+      dim => OrderByColumnSpec(dim.name, direction, DimensionOrder(dimensionOrderType))
+    )
+    this
+  }
+
+  /**
+    * Sort and limit the set of results of the group-by query
+    *
+    * @param n the upper limit of the number of results
+    * @param cols specify the ordering per group-by dimension
+    */
+  def limit(n: Int, cols: OrderByColumnSpec*): this.type = {
+    limitOpt = Option(n)
+    limitCols = cols
+    this
+  }
+
+  /**
+    * Specify whether or not to exclude null for all group-by dimensions
+    */
+  def setExcludeNulls(v: Boolean): this.type = {
+    excludeNullsOpt = Option(v)
+    this
+  }
+
+  /**
+    * Gives the resulting group-by query, wrt. the given query parameters (e.g., where, datasource, etc.)
+    *
+    * @return the resulting group-by query
+    */
+  def build()(implicit druidConfig: DruidConfig = DruidConfig.DefaultConfig): GroupByQuery = {
+
+    val havingOpt =
+      if (havingExpressions.isEmpty) None
+      else if (havingExpressions.size == 1) Option(havingExpressions.head)
+      else Option(definitions.AndHaving(havingExpressions))
+
+    val limitSpecOpt =
+      limitOpt.map { n =>
+        if (limitCols.nonEmpty) LimitSpec(limit = n, columns = limitCols)
+        else LimitSpec(limit = n, columns = dimensions.map(dim => OrderByColumnSpec(dim.name)))
+      }
+
+    // when excludeNullsOpt is Some(true)
+    // then set not null filtering for all dimensions
+    if (excludeNullsOpt.contains(true)) {
+      val excludeNullsExpressions = dimensions.map(dim => new Not(new NullDim(dim))).toList
+
+      this.where(new And(excludeNullsExpressions))
+    }
+
+    val conf = dataSourceOpt
+      .map(ds => druidConfig.copy(datasource = ds))
+      .getOrElse(druidConfig)
+
+    GroupByQuery(
+      aggregations = this.aggregations,
+      intervals = this.intervals,
+      filter = this.getFilters,
+      dimensions = this.dimensions.map(_.build()).toList,
+      granularity = this.granularityOpt.getOrElse(GranularityType.All),
+      having = havingOpt,
+      limitSpec = limitSpecOpt,
+      postAggregations = this.getPostAggs
+    )(conf)
+  }
+
+}

--- a/src/main/scala/ing/wbaa/druid/dql/expressions/Aggregation.scala
+++ b/src/main/scala/ing/wbaa/druid/dql/expressions/Aggregation.scala
@@ -1,0 +1,247 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ing.wbaa.druid.dql.expressions
+
+import ing.wbaa.druid.definitions._
+
+sealed trait AggregationExpression extends Named[AggregationExpression] {
+
+  protected[dql] def build(): Aggregation
+
+  def isComplex: Boolean = false
+}
+
+final class CountAgg(name: Option[String] = None) extends AggregationExpression {
+
+  override protected[dql] def build(): Aggregation = CountAggregation(this.getName)
+
+  override def alias(name: String): AggregationExpression = new CountAgg(Option(name))
+
+  override def getName: String = name.getOrElse("count")
+}
+
+final class LongSumAgg(fieldName: String, name: Option[String] = None)
+    extends AggregationExpression {
+
+  override protected[dql] def build(): Aggregation = LongSumAggregation(this.getName, fieldName)
+
+  override def alias(name: String): AggregationExpression = new LongSumAgg(fieldName, Option(name))
+
+  override def getName: String = name.getOrElse(s"long_sum_$fieldName")
+}
+
+final class LongMaxAgg(fieldName: String, name: Option[String] = None)
+    extends AggregationExpression {
+
+  override protected[dql] def build(): Aggregation =
+    LongMaxAggregation(this.getName, fieldName)
+
+  override def alias(name: String): AggregationExpression = new LongMaxAgg(fieldName, Option(name))
+
+  override def getName: String = name.getOrElse(s"long_max_$fieldName")
+}
+
+final class LongMinAgg(fieldName: String, name: Option[String] = None)
+    extends AggregationExpression {
+
+  override protected[dql] def build(): Aggregation =
+    LongMinAggregation(this.getName, fieldName)
+
+  override def alias(name: String): AggregationExpression = new LongMinAgg(fieldName, Option(name))
+
+  override def getName: String = name.getOrElse(s"long_min_$fieldName")
+}
+
+final class LongFirstAgg(fieldName: String, name: Option[String] = None)
+    extends AggregationExpression {
+
+  override protected[dql] def build(): Aggregation =
+    LongFirstAggregation(this.getName, fieldName)
+
+  override def alias(name: String): AggregationExpression =
+    new LongFirstAgg(fieldName, Option(name))
+
+  override def getName: String = name.getOrElse(s"long_first_$fieldName")
+}
+
+final class LongLastAgg(fieldName: String, name: Option[String] = None)
+    extends AggregationExpression {
+
+  override protected[dql] def build(): Aggregation =
+    LongLastAggregation(this.getName, fieldName)
+
+  override def alias(name: String): AggregationExpression = new LongLastAgg(fieldName, Option(name))
+
+  override def getName: String = name.getOrElse(s"long_last_$fieldName")
+}
+
+final class DoubleSumAgg(fieldName: String, name: Option[String] = None)
+    extends AggregationExpression {
+
+  override protected[dql] def build(): Aggregation =
+    DoubleSumAggregation(this.getName, fieldName)
+
+  override def alias(name: String): AggregationExpression =
+    new DoubleSumAgg(fieldName, Option(name))
+
+  override def getName: String = name.getOrElse(s"double_sum_$fieldName")
+}
+
+final class DoubleMaxAgg(fieldName: String, name: Option[String] = None)
+    extends AggregationExpression {
+
+  override protected[dql] def build(): Aggregation =
+    DoubleMaxAggregation(this.getName, fieldName)
+
+  override def alias(name: String): AggregationExpression =
+    new DoubleMaxAgg(fieldName, Option(name))
+
+  override def getName: String = name.getOrElse(s"double_max_$fieldName")
+}
+
+final class DoubleMinAgg(fieldName: String, name: Option[String] = None)
+    extends AggregationExpression {
+
+  override protected[dql] def build(): Aggregation =
+    DoubleMinAggregation(this.getName, fieldName)
+
+  override def alias(name: String): AggregationExpression =
+    new DoubleMinAgg(fieldName, Option(name))
+
+  override def getName: String = name.getOrElse(s"double_min_$fieldName")
+}
+
+final class DoubleFirstAgg(fieldName: String, name: Option[String] = None)
+    extends AggregationExpression {
+
+  override protected[dql] def build(): Aggregation =
+    DoubleFirstAggregation(this.getName, fieldName)
+
+  override def alias(name: String): AggregationExpression =
+    new DoubleFirstAgg(fieldName, Option(name))
+
+  override def getName: String = name.getOrElse(s"double_first_$fieldName")
+}
+
+final class DoubleLastAgg(fieldName: String, name: Option[String] = None)
+    extends AggregationExpression {
+
+  override protected[dql] def build(): Aggregation =
+    DoubleLastAggregation(this.getName, fieldName)
+
+  override def alias(name: String): AggregationExpression =
+    new DoubleLastAgg(fieldName, Option(name))
+
+  override def getName: String = name.getOrElse(s"double_last_$fieldName")
+}
+
+final case class ThetaSketchAgg(fieldName: String,
+                                name: Option[String] = None,
+                                isInputThetaSketch: Boolean = false,
+                                size: Long = ThetaSketchAgg.DefaultSize)
+    extends AggregationExpression {
+
+  override protected[dql] def build(): Aggregation =
+    ThetaSketchAggregation(
+      this.getName,
+      fieldName,
+      isInputThetaSketch,
+      size
+    )
+
+  override def alias(name: String): ThetaSketchAgg = copy(name = Option(name))
+
+  override def isComplex: Boolean = true
+
+  def isInputThetaSketch(v: Boolean): ThetaSketchAgg = copy(isInputThetaSketch = v)
+
+  def withSize(size: Long): ThetaSketchAgg = copy(size = size)
+
+  def set(isInputThetaSketch: Boolean = false,
+          size: Long = ThetaSketchAgg.DefaultSize): ThetaSketchAgg =
+    copy(isInputThetaSketch = isInputThetaSketch, size = size)
+
+  override def getName: String = name.getOrElse(s"theta_sketch_$fieldName")
+}
+
+object ThetaSketchAgg {
+  final val DefaultSize = 16384
+}
+
+final case class HyperUniqueAgg(fieldName: String,
+                                name: Option[String] = None,
+                                isInputHyperUnique: Boolean = false,
+                                round: Boolean = false)
+    extends AggregationExpression {
+
+  override protected[dql] def build(): Aggregation =
+    HyperUniqueAggregation(
+      this.getName,
+      fieldName,
+      isInputHyperUnique,
+      round
+    )
+  override def alias(name: String): HyperUniqueAgg = copy(name = Option(name))
+
+  override def isComplex: Boolean = true
+
+  def setInputHyperUnique(v: Boolean): HyperUniqueAgg = copy(isInputHyperUnique = v)
+
+  def setRound(v: Boolean): HyperUniqueAgg = copy(round = v)
+
+  def set(isInputHyperUnique: Boolean = false, isRound: Boolean = false): HyperUniqueAgg =
+    copy(isInputHyperUnique = isInputHyperUnique, round = isRound)
+
+  override def getName: String = name.getOrElse(s"hyper_unique_$fieldName")
+}
+
+final case class InFilteredAgg(dimension: String,
+                               values: Seq[String],
+                               aggregator: Aggregation,
+                               name: Option[String] = None)
+    extends AggregationExpression {
+
+  override protected[dql] def build(): Aggregation =
+    InFilteredAggregation(
+      this.getName,
+      InFilter(dimension, values),
+      aggregator
+    )
+
+  override def alias(name: String): InFilteredAgg = copy(name = Option(name))
+
+  override def getName: String = name.getOrElse(s"in_filtered_$dimension")
+}
+
+final case class SelectorFilteredAgg(dimension: String,
+                                     value: Option[String] = None,
+                                     aggregator: Aggregation,
+                                     name: Option[String] = None)
+    extends AggregationExpression {
+
+  override protected[dql] def build(): Aggregation =
+    SelectorFilteredAggregation(
+      this.getName,
+      SelectFilter(dimension, value),
+      aggregator
+    )
+
+  override def alias(name: String): SelectorFilteredAgg = copy(name = Option(name))
+
+  override def getName: String = name.getOrElse(s"selector_filtered_$dimension")
+}

--- a/src/main/scala/ing/wbaa/druid/dql/expressions/Filtering.scala
+++ b/src/main/scala/ing/wbaa/druid/dql/expressions/Filtering.scala
@@ -1,0 +1,218 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ing.wbaa.druid.dql.expressions
+
+import ing.wbaa.druid.{ definitions, DimensionOrderType }
+import ing.wbaa.druid.definitions._
+import ing.wbaa.druid.dql.Dim
+
+sealed trait FilteringExpression {
+
+  protected[dql] def createFilter: Filter
+
+  protected[dql] def createHaving: Having
+
+  def asFilter: Filter = createFilter
+
+  def asHaving: Having = this match {
+    case _: FilterOnlyOperator => FilterHaving(this.asFilter)
+    case _                     => createHaving
+  }
+
+  def or(others: FilteringExpression*): FilteringExpression = new Or(this :: others.toList)
+
+  def and(others: FilteringExpression*): FilteringExpression = new And(this :: others.toList)
+}
+
+class And(expressions: List[FilteringExpression]) extends FilteringExpression {
+  override protected[dql] def createFilter: Filter = AndFilter(expressions.map(_.createFilter))
+  override protected[dql] def createHaving: Having = AndHaving(expressions.map(_.createHaving))
+}
+
+class Or(expressions: List[FilteringExpression]) extends FilteringExpression {
+  override protected[dql] def createFilter: Filter = OrFilter(expressions.map(_.createFilter))
+  override protected[dql] def createHaving: Having = OrHaving(expressions.map(_.createHaving))
+}
+
+class Not(val op: FilteringExpression) extends FilteringExpression {
+  override protected[dql] def createFilter: Filter = NotFilter(op.createFilter)
+  override protected[dql] def createHaving: Having =
+    op match {
+      case _: FilterOnlyOperator => FilterHaving(NotFilter(op.createFilter))
+      case _                     => NotHaving(op.createHaving)
+    }
+}
+
+class EqString(dim: Dim, value: String) extends FilteringExpression {
+  override protected[dql] def createFilter: Filter =
+    SelectFilter(dim.name, Option(value), dim.extractionFnOpt)
+  override protected[dql] def createHaving: Having =
+    if (dim.extractionFnOpt.isDefined) FilterHaving(this.createFilter)
+    else DimSelectorHaving(dim.name, value)
+
+}
+
+class EqDouble(dim: Dim, value: Double) extends FilteringExpression {
+  override protected[dql] def createFilter: Filter =
+    SelectFilter(dim.name, Option(value.toString), dim.extractionFnOpt)
+  override protected[dql] def createHaving: Having =
+    if (dim.extractionFnOpt.isDefined) FilterHaving(this.createFilter)
+    else EqualToHaving(dim.name, value)
+}
+
+trait FilterOnlyOperator extends FilteringExpression {
+  override protected[dql] def createHaving: Having = FilterHaving(this.createFilter)
+}
+
+class In(dim: Dim, values: List[String]) extends FilteringExpression with FilterOnlyOperator {
+  override protected[dql] def createFilter: Filter = InFilter(dim.name, values)
+}
+
+class Like(dim: Dim, pattern: String) extends FilteringExpression with FilterOnlyOperator {
+  override protected[dql] def createFilter: Filter = LikeFilter(dim.name, pattern)
+}
+
+class Regex(dim: Dim, pattern: String) extends FilteringExpression with FilterOnlyOperator {
+  override protected[dql] def createFilter: Filter = RegexFilter(dim.name, pattern)
+}
+
+class NullDim(dim: Dim) extends FilteringExpression with FilterOnlyOperator {
+  override protected[dql] def createFilter: Filter = SelectFilter(dim.name, None)
+}
+
+class Gt(dim: Dim, value: Double) extends FilteringExpression {
+  override protected[dql] def createFilter: Filter =
+    BoundFilter(
+      dimension = dim.name,
+      lower = Option(value.toString),
+      lowerStrict = Some(false),
+      ordering = Option(DimensionOrderType.Numeric),
+      extractionFn = dim.extractionFnOpt
+    )
+
+  override protected[dql] def createHaving: Having =
+    if (dim.extractionFnOpt.isDefined) FilterHaving(this.createFilter)
+    else GreaterThanHaving(dim.name, value)
+}
+
+class GtEq(dim: Dim, value: Double) extends FilteringExpression {
+  override protected[dql] def createFilter: Filter =
+    BoundFilter(
+      dimension = dim.name,
+      lower = Option(value.toString),
+      lowerStrict = Some(true),
+      ordering = Option(DimensionOrderType.Numeric),
+      extractionFn = dim.extractionFnOpt
+    )
+
+  override protected[dql] def createHaving: Having =
+    if (dim.extractionFnOpt.isDefined) FilterHaving(this.createFilter)
+    else OrHaving(EqualToHaving(dim.name, value) :: GreaterThanHaving(dim.name, value) :: Nil)
+}
+
+class Lt(dim: Dim, value: Double) extends FilteringExpression {
+  override protected[dql] def createFilter: Filter =
+    BoundFilter(
+      dimension = dim.name,
+      upper = Option(value.toString),
+      upperStrict = Some(false),
+      ordering = Option(DimensionOrderType.Numeric),
+      extractionFn = dim.extractionFnOpt
+    )
+
+  override protected[dql] def createHaving: Having =
+    if (dim.extractionFnOpt.isDefined) FilterHaving(this.createFilter)
+    else LessThanHaving(dim.name, value)
+}
+
+class LtEq(dim: Dim, value: Double) extends FilteringExpression {
+
+  override protected[dql] def createFilter: Filter =
+    BoundFilter(
+      dimension = dim.name,
+      upper = Option(value.toString),
+      upperStrict = Some(true),
+      ordering = Option(DimensionOrderType.Numeric),
+      extractionFn = dim.extractionFnOpt
+    )
+
+  override protected[dql] def createHaving: Having =
+    if (dim.extractionFnOpt.isDefined) FilterHaving(this.createFilter)
+    else OrHaving(EqualToHaving(dim.name, value) :: LessThanHaving(dim.name, value) :: Nil)
+
+}
+
+case class Bound(dimension: String,
+                 lower: Option[String] = None,
+                 upper: Option[String] = None,
+                 lowerStrict: Option[Boolean] = None,
+                 upperStrict: Option[Boolean] = None,
+                 ordering: Option[DimensionOrderType] = None,
+                 extractionFn: Option[ExtractionFn] = None)
+    extends FilteringExpression
+    with FilterOnlyOperator {
+
+  def withOrdering(v: DimensionOrderType): Bound = copy(ordering = Option(v))
+
+  def withExtractionFn(fn: ExtractionFn): Bound = copy(extractionFn = Option(fn))
+
+  override protected[dql] def createFilter: Filter =
+    BoundFilter(dimension, lower, upper, lowerStrict, upperStrict, ordering, extractionFn)
+
+}
+
+class ColumnComparison(dimensions: List[Dim]) extends FilteringExpression with FilterOnlyOperator {
+  override protected[dql] def createFilter: Filter = {
+
+    val dimSpecs = dimensions.map { dim =>
+      dim.extractionFnOpt match {
+        case Some(extractionFn) =>
+          ExtractionDimension(dimension = dim.name,
+                              outputName = dim.outputNameOpt,
+                              outputType = dim.outputTypeOpt,
+                              extractionFn = extractionFn)
+        case None =>
+          Dimension(dimension = dim.name,
+                    outputName = dim.outputNameOpt,
+                    outputType = dim.outputTypeOpt)
+      }
+    }
+    ColumnComparisonFilter(dimSpecs)
+  }
+}
+
+class Interval(dim: Dim, values: List[String]) extends FilteringExpression with FilterOnlyOperator {
+  override protected[dql] def createFilter: Filter =
+    IntervalFilter(dim.name, values, dim.extractionFnOpt)
+}
+
+class Contains(dim: Dim, value: String, caseSensitive: Boolean)
+    extends FilteringExpression
+    with FilterOnlyOperator {
+
+  override protected[dql] def createFilter: Filter =
+    SearchFilter(dim.name,
+                 query = ContainsCaseSensitive(value, Option(caseSensitive)),
+                 dim.extractionFnOpt)
+}
+class InsensitiveContains(dim: Dim, value: String)
+    extends FilteringExpression
+    with FilterOnlyOperator {
+  override protected[dql] def createFilter: Filter =
+    SearchFilter(dim.name, query = definitions.ContainsInsensitive(value), dim.extractionFnOpt)
+}

--- a/src/main/scala/ing/wbaa/druid/dql/expressions/Named.scala
+++ b/src/main/scala/ing/wbaa/druid/dql/expressions/Named.scala
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ing.wbaa.druid.dql.expressions
+
+trait Named[T] {
+
+  def alias(name: String): T
+  def as(name: String): T = alias(name)
+
+  def getName: String
+
+}

--- a/src/main/scala/ing/wbaa/druid/dql/expressions/PostAggregation.scala
+++ b/src/main/scala/ing/wbaa/druid/dql/expressions/PostAggregation.scala
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ing.wbaa.druid.dql.expressions
+
+import ing.wbaa.druid.definitions._
+
+sealed trait PostAggregatorExpression extends Named[PostAggregatorExpression] {
+  private[dql] def build(complexAggNames: Set[String]): PostAggregation
+}
+
+class FieldAccessPostAgg(fieldName: String, name: Option[String] = None)
+    extends PostAggregatorExpression {
+
+  override private[dql] def build(complexAggNames: Set[String]): PostAggregation =
+    if (complexAggNames.contains(fieldName)) FieldAccessPostAggregation(fieldName, name)
+    else FieldAccessPostAggregation(fieldName, name)
+
+  override def alias(name: String): PostAggregatorExpression =
+    new FieldAccessPostAgg(fieldName, Option(name))
+
+  override def getName: String = name.getOrElse(fieldName)
+}
+
+class ConstantPostAgg(value: Double, name: Option[String] = None) extends PostAggregatorExpression {
+
+  override private[dql] def build(complexAggNames: Set[String]): PostAggregation =
+    ConstantPostAggregation(value, name)
+
+  override def alias(name: String): PostAggregatorExpression =
+    new ConstantPostAgg(value, Option(name))
+
+  override def getName: String = name.getOrElse("c_" + value)
+}
+
+sealed trait PostAggregationExpression extends Named[PostAggregationExpression] {
+  protected[dql] def build(complexAggNames: Set[String]): PostAggregation
+}
+
+case class ArithmeticPostAgg(leftField: PostAggregatorExpression,
+                             rightField: PostAggregatorExpression,
+                             fn: ArithmeticFunction,
+                             name: Option[String] = None,
+                             ordering: Option[Ordering] = None)
+    extends PostAggregationExpression {
+
+  override protected[dql] def build(complexAggNames: Set[String]): PostAggregation =
+    ArithmeticPostAggregation(
+      name = this.getName,
+      fn = fn,
+      fields = Seq(leftField.build(complexAggNames), rightField.build(complexAggNames))
+    )
+
+  def withOrdering(ordering: Ordering): PostAggregationExpression =
+    copy(ordering = Option(ordering))
+
+  def floatingPointOrdering: PostAggregationExpression =
+    copy(ordering = Some(Ordering.FloatingPoint))
+
+  def numericFirstOrdering: PostAggregationExpression = copy(ordering = Some(Ordering.NumericFirst))
+
+  override def alias(name: String): PostAggregationExpression = copy(name = Option(name))
+
+  override def getName: String = name.getOrElse(s"post_${leftField}_${fn}_${rightField}")
+}
+
+case class HyperUniqueCardinalityPostAgg(fieldName: String, name: Option[String] = None)
+    extends PostAggregationExpression {
+
+  override protected[dql] def build(complexAggNames: Set[String]): PostAggregation =
+    HyperUniqueCardinalityPostAggregation(this.getName, fieldName)
+
+  override def alias(name: String): PostAggregationExpression = copy(name = Option(name))
+
+  override def getName: String = name.getOrElse(s"post_${fieldName}")
+}

--- a/src/test/scala/ing/wbaa/druid/definitions/HavingSpec.scala
+++ b/src/test/scala/ing/wbaa/druid/definitions/HavingSpec.scala
@@ -29,7 +29,7 @@ class HavingSpec extends Matchers with WordSpecLike with ScalaFutures {
       "be encoded properly" in {
         val having: Having = FilterHaving(SelectFilter("dim", "value"))
         having.asJson.noSpaces shouldBe
-        """{"filter":{"dimension":"dim","value":"value","type":"selector"},"type":"filter"}"""
+        """{"filter":{"dimension":"dim","value":"value","extractionFn":null,"type":"selector"},"type":"filter"}"""
       }
 
       "should behave the same as usual filter" in new TestContext {

--- a/src/test/scala/ing/wbaa/druid/dql/DQLSpec.scala
+++ b/src/test/scala/ing/wbaa/druid/dql/DQLSpec.scala
@@ -1,0 +1,230 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ing.wbaa.druid.dql
+
+import ing.wbaa.druid.{ GroupByQuery, TimeSeriesQuery, TopNQuery }
+import ing.wbaa.druid.definitions._
+import org.scalatest.{ Matchers, WordSpec }
+import org.scalatest.concurrent._
+import org.scalatest.time.{ Millis, Seconds, Span }
+import ing.wbaa.druid.dql.DSL._
+import io.circe.generic.auto._
+
+class DQLSpec extends WordSpec with Matchers with ScalaFutures {
+
+  implicit override val patienceConfig =
+    PatienceConfig(timeout = Span(5, Seconds), interval = Span(5, Millis))
+  private val totalNumberOfEntries = 39244
+
+  case class TimeseriesCount(count: Int)
+  case class GroupByIsAnonymous(isAnonymous: String, count: Int)
+  case class TopCountry(count: Int, countryName: Option[String])
+  case class AggregatedFilteredAnonymous(count: Int, isAnonymous: String, filteredCount: Int)
+  case class PostAggregationAnonymous(count: Int, isAnonymous: String, halfCount: Double)
+
+  "DQL TimeSeriesQuery" should {
+    "successfully be interpreted by Druid" in {
+
+      val query: TimeSeriesQuery = DQL
+        .granularity(GranularityType.Hour)
+        .interval("2011-06-01/2017-06-01")
+        .agg(count as "count")
+        .build()
+
+      val request = query.execute()
+
+      whenReady(request) { response =>
+        response.list[TimeseriesCount].map(_.count).sum shouldBe totalNumberOfEntries
+      }
+    }
+
+    "extract the data and return a map with the timestamps as keys" in {
+      val query: TimeSeriesQuery = DQL
+        .granularity(GranularityType.Hour)
+        .interval("2011-06-01/2017-06-01")
+        .agg(count as "count")
+        .build()
+
+      val request = query.execute()
+
+      whenReady(request) { response =>
+        response
+          .series[TimeseriesCount]
+          .flatMap { case (_, items) => items.map(_.count) }
+          .sum shouldBe totalNumberOfEntries
+      }
+    }
+  }
+
+  "DQL GroupByQuery" should {
+    "successfully be interpreted by Druid" in {
+      val query: GroupByQuery = DQL
+        .interval("2011-06-01/2017-06-01")
+        .agg(count as "count")
+        .groupBy('isAnonymous)
+        .build()
+
+      val request = query.execute()
+
+      whenReady(request) { response =>
+        response.list[GroupByIsAnonymous].map(_.count).sum shouldBe totalNumberOfEntries
+      }
+    }
+
+    "successfully be interpreted by Druid when using lower granularity" in {
+      val query = DQL
+        .interval("2011-06-01/2017-06-01")
+        .agg(count as "count")
+        .groupBy('isAnonymous)
+        .granularity(GranularityType.Hour)
+        .build()
+
+      val request = query.execute()
+
+      whenReady(request) { response =>
+        response.list[GroupByIsAnonymous].map(_.count).sum shouldBe totalNumberOfEntries
+      }
+    }
+  }
+
+  "DQL TopNQuery" should {
+    "successfully be interpreted by Druid" in {
+      val topNLimit = 5
+
+      val query = DQL
+        .agg(count as "count")
+        .interval("2011-06-01/2017-06-01")
+        .topN(dimension = 'countryName, metric = "count", threshold = topNLimit)
+        .build()
+
+      val request = query.execute()
+
+      whenReady(request) { response =>
+        val topN = response.list[TopCountry]
+
+        topN.size shouldBe topNLimit
+
+        topN.head shouldBe TopCountry(count = 35445, countryName = None)
+        topN(1) shouldBe TopCountry(count = 528, countryName = Some("United States"))
+        topN(2) shouldBe TopCountry(count = 256, countryName = Some("Italy"))
+        topN(3) shouldBe TopCountry(count = 234, countryName = Some("United Kingdom"))
+        topN(4) shouldBe TopCountry(count = 205, countryName = Some("France"))
+      }
+    }
+
+    "also work with a filter" in {
+
+      val query = DQL
+        .agg(count as "count")
+        .interval("2011-06-01/2017-06-01")
+        .topN(dimension = 'countryName, metric = "count", threshold = 5)
+        .where('countryName === "United States" or 'countryName === "Italy")
+        .build()
+
+      val request = query.execute()
+
+      whenReady(request) { response =>
+        val topN = response.list[TopCountry]
+        topN.size shouldBe 2
+        topN.head shouldBe TopCountry(count = 528, countryName = Some("United States"))
+        topN(1) shouldBe TopCountry(count = 256, countryName = Some("Italy"))
+      }
+    }
+  }
+
+  "DQL also work with 'in' filtered aggregations" should {
+    "successfully be interpreted by Druid" in {
+
+      val query = DQL
+        .agg('count.longSum as "count")
+        .agg(
+          'channel.inFiltered('count.longSum as "filteredCount", "#en.wikipedia", "#de.wikipedia")
+        )
+        .interval("2011-06-01/2017-06-01")
+        .topN(dimension = 'isAnonymous, metric = "count", threshold = 5)
+        .build()
+
+      val request = query.execute()
+
+      whenReady(request) { response =>
+        val topN = response.list[AggregatedFilteredAnonymous]
+        topN.size shouldBe 2
+        topN.head shouldBe AggregatedFilteredAnonymous(count = 35445,
+                                                       filteredCount = 12374,
+                                                       isAnonymous = "false")
+        topN(1) shouldBe AggregatedFilteredAnonymous(count = 3799,
+                                                     filteredCount = 1698,
+                                                     isAnonymous = "true")
+      }
+    }
+  }
+
+  "DQL also work with 'selector' filtered aggregations" should {
+    "successfully be interpreted by Druid" in {
+
+      val query = DQL
+        .topN('isAnonymous, metric = "count", threshold = 5)
+        .agg('count.longSum as "count")
+        .agg(
+          'channel.selectorFiltered(aggregator = 'count.longSum as "filteredCount",
+                                    value = "#en.wikipedia") as "SelectorFilteredAgg"
+        )
+        .interval("2011-06-01/2017-06-01")
+        .build()
+
+      val request = query.execute()
+
+      whenReady(request) { response =>
+        val topN = response.list[AggregatedFilteredAnonymous]
+        topN.size shouldBe 2
+        topN.head shouldBe AggregatedFilteredAnonymous(count = 35445,
+                                                       filteredCount = 9993,
+                                                       isAnonymous = "false")
+        topN(1) shouldBe AggregatedFilteredAnonymous(count = 3799,
+                                                     filteredCount = 1556,
+                                                     isAnonymous = "true")
+      }
+    }
+  }
+
+  "DQL also work with post 'arithmetic' post-aggregations" should {
+    "successfully be interpreted by Druid" in {
+
+      val query: TopNQuery = DQL
+        .topN('isAnonymous, metric = "count", threshold = 5)
+        .agg(count)
+        .postAgg(('count / 2) as "halfCount")
+        .interval("2011-06-01/2017-06-01")
+        .build()
+
+      val request = query.execute()
+
+      whenReady(request) { response =>
+        val topN = response.list[PostAggregationAnonymous]
+        topN.size shouldBe 2
+        topN.head shouldBe PostAggregationAnonymous(count = 35445,
+                                                    halfCount = 17722.5,
+                                                    isAnonymous = "false")
+        topN(1) shouldBe PostAggregationAnonymous(count = 3799,
+                                                  halfCount = 1899.5,
+                                                  isAnonymous = "true")
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
This is the implementation of Druid query language (DQL). In brief it provides the following:
  - flow-based builders for timeseries, group-by and top-n queries
  - filter expressions
  - having expressions
  - aggregation and post-aggregation expressions

GH-32

The example below demonstrates a group-by query:

```
case class GroupByIsAnonymous(isAnonymous: String, country: String, count: Int)

val query: GroupByQuery = DQL
    .granularity(GranularityType.Day)
    .interval("2011-06-01/2017-06-01")
    .agg(count as "count")
    .where('countryName.isNotNull)
    .groupBy('isAnonymous, 'countryName.extract(UpperExtractionFn()) as "country")
    .having('count > 100 and 'count < 200)
    .limit(10, 'count.desc(DimensionOrderType.numeric))
    .build()
      
val response = query.execute().map(_.list[GroupByIsAnonymous])
val result: List[GroupByIsAnonymous] = Await.result(response, 10.seconds)
```
In [docs/dql.md](https://github.com/anskarl/scruid/blob/feature/dql/docs/dql.md) you can find documentation and examples.

