### PR TITLE
Upgrades circe to version 0.10.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -43,8 +43,8 @@ lazy val commonSettings: Seq[Setting[_]] = Seq(
       s"git@github.com:${bintrayOrganization.value.get}/${name.value}.git"
     )
   ),
-  crossScalaVersions in ThisBuild := Seq("2.11.12", "2.12.7"),
-  scalaVersion in ThisBuild := "2.12.7",
+  crossScalaVersions in ThisBuild := Seq("2.11.12", "2.12.8"),
+  scalaVersion in ThisBuild := "2.12.8",
   scalacOptions ++= Seq(Opts.compile.deprecation, "-Xlint", "-feature"),
   scalacOptions ++= PartialFunction
     .condOpt(CrossVersion.partialVersion(scalaVersion.value)) {
@@ -55,7 +55,7 @@ lazy val commonSettings: Seq[Setting[_]] = Seq(
   publishArtifact in Test := false
 ) ++ Seq(Compile, Test).flatMap(c => scalacOptions in (c, console) --= unusedWarnings)
 
-val circeVersion = "0.9.3"
+val circeVersion = "0.10.1"
 lazy val root = (project in file("."))
   .settings(commonSettings)
   .settings(
@@ -67,8 +67,8 @@ lazy val root = (project in file("."))
       "io.circe"          %% "circe-parser"    % circeVersion,
       "io.circe"          %% "circe-generic"   % circeVersion,
       "io.circe"          %% "circe-java8"     % circeVersion,
-      "com.typesafe.akka" %% "akka-http"       % "10.1.3",
-      "de.heikoseeberger" %% "akka-http-circe" % "1.21.0",
+      "com.typesafe.akka" %% "akka-http"       % "10.1.5",
+      "de.heikoseeberger" %% "akka-http-circe" % "1.22.0",
       "ca.mrvisser"       %% "sealerate"       % "0.0.5",
       "ch.qos.logback"    % "logback-classic"  % "1.2.3",
       "org.scalactic"     %% "scalactic"       % "3.0.5",

--- a/src/main/scala/ing/wbaa/druid/DruidClient.scala
+++ b/src/main/scala/ing/wbaa/druid/DruidClient.scala
@@ -31,7 +31,7 @@ import org.slf4j.LoggerFactory
 
 import scala.concurrent.Future
 
-object DruidClient extends FailFastCirceSupport with TimeInstances {
+object DruidClient extends FailFastCirceSupport with JavaTimeDecoders {
   private val logger = LoggerFactory.getLogger(getClass)
 
   implicit val system       = ActorSystem()

--- a/src/main/scala/ing/wbaa/druid/DruidResponse.scala
+++ b/src/main/scala/ing/wbaa/druid/DruidResponse.scala
@@ -51,7 +51,7 @@ case class DruidResponse(results: List[DruidResult], queryType: QueryType) {
 
 case class DruidResult(timestamp: ZonedDateTime, result: Json)
 
-object DruidResult extends TimeInstances {
+object DruidResult extends JavaTimeDecoders {
   private def extractResultField(c: HCursor): ACursor = {
     val result = c.downField("result")
     val event  = c.downField("event")


### PR DESCRIPTION
Upgrades circe to version 0.10.1

  - replaces TimeInstances with JavaTimeDecoders
  - upgrades Scala to 2.12.8
  - upgrades Akka HTTP to 10.1.5
  - upgrades akka-http-circe to 1.22.0

GH-47