### PR TITLE
Adds support for Geographic queries

### DIFF
--- a/docs/dql.md
+++ b/docs/dql.md
@@ -292,6 +292,29 @@ To define a negation of an operator, you can use the operator `not`:
 not('dim1 between (10, 100))
 ```
 
+#### Operators for geographic queries
+
+Druid supports filtering spatially indexed dimensions based on an origin and a bound. For defining spatially indexed 
+dimensions, see official the [Druid documentation for Geographic Queries](http://druid.io/docs/latest/development/geo.html).
+
+DQL supports geographic queries on spatially indexed dimensions with the `within` operator.
+
+You can filter spatially indexed dimensions by specifying the bounds of minimum and maximum coordinates.
+Assume, for example, that the dimension named as `geodim` is spatially indexed in some datasource in Druid. 
+You can perform a geographic query by specifying the minimum and maximum coordinates as below: 
+
+```scala
+'geodim within (minCoords = Seq(37.970540, 23.724153), maxCoords = Seq(37.972166, 23.727828))
+```
+
+Alternatively, you can filter spatially indexed columns by specifying the origin coordinates and a distance either
+in kilometers, miles or directly in degrees:
+```scala
+import ing.wbaa.druid.dql.expressions.Distance.DistanceUnit
+
+'geodim within (coords = Seq(37.971515, 23.726717), distance = 4.0, unit = DistanceUnit.KM)
+```
+
 ## Aggregations
 
 Aggregations are functions that summarize data. To add one or more aggregation functions in a DQL query you can

--- a/src/main/scala/ing/wbaa/druid/dql/Dim.scala
+++ b/src/main/scala/ing/wbaa/druid/dql/Dim.scala
@@ -364,6 +364,31 @@ case class Dim private[dql] (name: String,
   def containsInsensitive(value: String): FilteringExpression =
     new InsensitiveContains(this, value)
 
+  /**
+    * Filter spatially indexed columns by specifying the bounds of minimum and maximum coordinates
+    *
+    * @param minCoords a list of minimum dimension coordinates for coordinates [x, y, z, ...]
+    * @param maxCoords a list of maximum dimension coordinates for coordinates [x, y, z, ...]
+    *
+    * @return the resulting spatial filtering expression
+    */
+  def within(minCoords: Iterable[Double], maxCoords: Iterable[Double]): FilteringExpression =
+    new GeoRectangular(this, minCoords, maxCoords)
+
+  /**
+    * Filter spatially indexed columns by specifying the origin coordinates and a distance
+    *
+    * @param coords a list of origin coordinates in the form [x, y, z, ...]
+    * @param distance the distance from origin coordinates.
+    *                 It can be specified in kilometers, miles or radius degrees (default)
+    *
+    * @return the resulting spatial filtering expression
+    */
+  def within(coords: Iterable[Double],
+             distance: Double,
+             unit: Distance.Unit = Distance.DistanceUnit.DEGREES): FilteringExpression =
+    new GeoRadius(this, coords, Distance.toDegrees(distance, unit))
+
   // --------------------------------------------------------------------------
   // --- Functions for creating OrderByColumnSpec
   // --------------------------------------------------------------------------

--- a/src/main/scala/ing/wbaa/druid/dql/expressions/Distance.scala
+++ b/src/main/scala/ing/wbaa/druid/dql/expressions/Distance.scala
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ing.wbaa.druid.dql.expressions
+
+object Distance {
+  type Unit = DistanceUnit.Value
+
+  final val DegreesToRadians = math.Pi / 180
+  final val RadiansToDegrees = 1 / DegreesToRadians
+
+  /**
+    * See http://en.wikipedia.org/wiki/Earth_radius for details
+    */
+  final val EarthEquatorialRadiusKm = 6378.1370
+  final val KmToMiles               = 0.621371192
+  final val EarthEquatorialRadiusMi = EarthEquatorialRadiusKm * KmToMiles
+
+  object DistanceUnit extends Enumeration {
+
+    final val KM      = Value(0, "KM")
+    final val MI      = Value(1, "MI")
+    final val DEGREES = Value(2, "DEGREES")
+
+    final val Kilometers = KM
+    final val Miles      = MI
+    final val Degrees    = DEGREES
+
+  }
+
+  def toDegrees(distance: Double, unit: DistanceUnit.Value): Double =
+    unit match {
+      case DistanceUnit.KM =>
+        val radians = distance / EarthEquatorialRadiusKm
+        radians * RadiansToDegrees
+
+      case DistanceUnit.MI =>
+        val radians = distance / EarthEquatorialRadiusMi
+
+        radians * RadiansToDegrees
+
+      case DistanceUnit.DEGREES =>
+        distance
+
+    }
+
+}

--- a/src/main/scala/ing/wbaa/druid/dql/expressions/Filtering.scala
+++ b/src/main/scala/ing/wbaa/druid/dql/expressions/Filtering.scala
@@ -216,3 +216,19 @@ class InsensitiveContains(dim: Dim, value: String)
   override protected[dql] def createFilter: Filter =
     SearchFilter(dim.name, query = definitions.ContainsInsensitive(value), dim.extractionFnOpt)
 }
+
+class GeoRectangular(dim: Dim, minCoords: Iterable[Double], maxCoords: Iterable[Double])
+    extends FilteringExpression
+    with FilterOnlyOperator {
+
+  override protected[dql] def createFilter: Filter =
+    SpatialFilter(dimension = dim.name, bound = RectangularBound(minCoords, maxCoords))
+}
+
+class GeoRadius(dim: Dim, coords: Iterable[Double], radius: Double)
+    extends FilteringExpression
+    with FilterOnlyOperator {
+
+  override protected[dql] def createFilter: Filter =
+    SpatialFilter(dimension = dim.name, bound = RadiusBound(coords, radius))
+}


### PR DESCRIPTION
  - query spatially indexed columns based on an origin and a bound
  - adds 'within' operator in DQL for spatial queries
  - 'within' operator supports distances in Km, Mi and Degrees
  - adds examples in documentation

GH-46