### PR TITLE
Add healthcheck to DruidClient

### DIFF
--- a/src/main/scala/ing/wbaa/druid/DruidConfig.scala
+++ b/src/main/scala/ing/wbaa/druid/DruidConfig.scala
@@ -44,8 +44,11 @@ class DruidConfig(val host: String,
 
 object DruidConfig {
 
-  private val config      = ConfigFactory.load()
+  private val config = ConfigFactory.load()
+
   private val druidConfig = config.getConfig("druid")
+
+  val HealthEndpoint = "/status/health"
 
   implicit def asFiniteDuration(d: java.time.Duration): FiniteDuration =
     scala.concurrent.duration.Duration.fromNanos(d.toNanos)

--- a/src/test/scala/ing/wbaa/druid/DruidClientSpec.scala
+++ b/src/test/scala/ing/wbaa/druid/DruidClientSpec.scala
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ing.wbaa.druid
+
+import org.scalatest._
+import org.scalatest.concurrent._
+import org.scalatest.time._
+
+class DruidClientSpec extends WordSpec with Matchers with ScalaFutures {
+  implicit override val patienceConfig =
+    PatienceConfig(timeout = Span(5, Seconds), interval = Span(5, Millis))
+
+  "DruidClient" should {
+    "indicate that Druid is healthy" in {
+      whenReady(DruidClient.isHealthy()) { result =>
+        result shouldBe true
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds a function to the `DruidClient` to reach the `/status/health` endpoint of Druid. 