### PR TITLE
Fix strict mode in 'bound' filter

### DIFF
--- a/docs/dql.md
+++ b/docs/dql.md
@@ -196,10 +196,10 @@ When numbers are given to bound operators, then the ordering is numeric:
 'dim between(0.0, 10.0)
 
 // 0.0 <= dim <= 10.0
-'dim between(0.0, 10.0, lowerStrict = true, upperStrict = true)
+'dim between(0.0, 10.0, lowerStrict = false, upperStrict = false)
 
 // 0.0 <= dim < 10.0
-'dim between(0.0, 10.0, lowerStrict = true, upperStrict = false)
+'dim between(0.0, 10.0, lowerStrict = false, upperStrict = true)
 ```
 
 When strings are given to bound operators, then the ordering is lexicographic:
@@ -214,10 +214,10 @@ When strings are given to bound operators, then the ordering is lexicographic:
 'dim between("0.0", "10.0")
 
 // "0.0" <= dim <= "10.0"
-'dim between("0.0", "10.0", lowerStrict = true, upperStrict = true)
+'dim between("0.0", "10.0", lowerStrict = false, upperStrict = false)
 
 // "0.0" <= dim < "10.0"
-'dim between("0.0", "10.0", lowerStrict = true, upperStrict = false)
+'dim between("0.0", "10.0", lowerStrict = false, upperStrict = true)
 ```
 
 Furthermore, you can specify any other ordering (e.g. Alphanumeric) or define some extraction function:

--- a/src/main/scala/ing/wbaa/druid/dql/DSL.scala
+++ b/src/main/scala/ing/wbaa/druid/dql/DSL.scala
@@ -83,9 +83,9 @@ object DSL
     def ===(s: Dim): FilteringExpression = s === value
     def =!=(s: Dim): FilteringExpression = s =!= value
     def >(s: Dim): FilteringExpression   = s < value
-    def >=(s: Dim): FilteringExpression  = s =< value
+    def >=(s: Dim): FilteringExpression  = s <= value
     def <(s: Dim): FilteringExpression   = s > value
-    def =<(s: Dim): FilteringExpression  = s >= value
+    def <=(s: Dim): FilteringExpression  = s >= value
 
     def +(s: Symbol): PostAggregationExpression = arithmeticPostAgg(s, ArithmeticFunction.PLUS)
     def -(s: Symbol): PostAggregationExpression = arithmeticPostAgg(s, ArithmeticFunction.MINUS)

--- a/src/main/scala/ing/wbaa/druid/dql/Dim.scala
+++ b/src/main/scala/ing/wbaa/druid/dql/Dim.scala
@@ -203,7 +203,7 @@ case class Dim private[dql] (name: String,
   def isNotNull: FilteringExpression = FilteringExpressionOps.not(this.isNull)
 
   /**
-    * Filter based on a lower bound of dimension values, using numeric ordering.
+    * Filter based on a strict lower bound of dimension values, using numeric ordering.
     *
     * @return a bound filtering expression, with numeric ordering, specifying that the value of
     *         the dimension should be greater than the given number.
@@ -211,7 +211,7 @@ case class Dim private[dql] (name: String,
   def >(value: Double): FilteringExpression = new Gt(this, value)
 
   /**
-    * Filter based on a strict lower bound of dimension values, using numeric ordering.
+    * Filter based on a lower bound of dimension values, using numeric ordering.
     *
     * @return a bound filtering expression, with numeric ordering, specifying that the value of
     *         the dimension should be greater than, or equal to the given number.
@@ -219,7 +219,7 @@ case class Dim private[dql] (name: String,
   def >=(value: Double): FilteringExpression = new GtEq(this, value)
 
   /**
-    * Filter based on a upper bound of dimension values, using numeric ordering.
+    * Filter based on a strict upper bound of dimension values, using numeric ordering.
     *
     * @return a bound filtering expression, with numeric ordering, specifying that the value of
     *         the dimension should be less than the given number.
@@ -227,12 +227,12 @@ case class Dim private[dql] (name: String,
   def <(value: Double): FilteringExpression = new Lt(this, value)
 
   /**
-    * Filter based on a strict upper bound of dimension values, using numeric ordering.
+    * Filter based on an upper bound of dimension values, using numeric ordering.
     *
     * @return a bound filtering expression, with numeric ordering, specifying that the value of
     *         the dimension should be less than, or equal to the given number.
     */
-  def =<(value: Double): FilteringExpression = new LtEq(this, value)
+  def <=(value: Double): FilteringExpression = new LtEq(this, value)
 
   /**
     * Filter on ranges of dimension values, using numeric ordering.

--- a/src/main/scala/ing/wbaa/druid/dql/expressions/Filtering.scala
+++ b/src/main/scala/ing/wbaa/druid/dql/expressions/Filtering.scala
@@ -114,7 +114,7 @@ class Gt(dim: Dim, value: Double) extends FilteringExpression {
     BoundFilter(
       dimension = dim.name,
       lower = Option(value.toString),
-      lowerStrict = Some(false),
+      lowerStrict = Some(true),
       ordering = Option(DimensionOrderType.Numeric),
       extractionFn = dim.extractionFnOpt
     )
@@ -129,7 +129,7 @@ class GtEq(dim: Dim, value: Double) extends FilteringExpression {
     BoundFilter(
       dimension = dim.name,
       lower = Option(value.toString),
-      lowerStrict = Some(true),
+      lowerStrict = Some(false),
       ordering = Option(DimensionOrderType.Numeric),
       extractionFn = dim.extractionFnOpt
     )
@@ -144,7 +144,7 @@ class Lt(dim: Dim, value: Double) extends FilteringExpression {
     BoundFilter(
       dimension = dim.name,
       upper = Option(value.toString),
-      upperStrict = Some(false),
+      upperStrict = Some(true),
       ordering = Option(DimensionOrderType.Numeric),
       extractionFn = dim.extractionFnOpt
     )
@@ -160,7 +160,7 @@ class LtEq(dim: Dim, value: Double) extends FilteringExpression {
     BoundFilter(
       dimension = dim.name,
       upper = Option(value.toString),
-      upperStrict = Some(true),
+      upperStrict = Some(false),
       ordering = Option(DimensionOrderType.Numeric),
       extractionFn = dim.extractionFnOpt
     )


### PR DESCRIPTION
Fixes strict mode of **'bound' filter** in Scruid DSL so that it is in agreement with Druid's documentation. 

According to [Druid's documentation](http://druid.io/docs/latest/querying/filters.html) strict comparison in bound filter means using `>` instead of `>=` and `<` instead of `<=`. 
This is currently the other way around in Scruid's DSL. The fix makes the behavior consistent with Druid. 

Also, fixes a small inconsistency in the DSL. 
Currently 'greaterThanEquals' is expressed as `>=`, whereas 'lessThanEquals' is expressed as `=<`. 
The fix makes 'lessThanEquals' to be `<=`. 

@anskarl the changes are in the DSL so can you please validate as well? 

