### PR TITLE
Query context support

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,26 @@ val series: Future[Map[ZonedDateTime, TimeseriesCount]] = response.map(_.series[
 
 To get the timeseries data from this `Future[DruidRespones]` you can run `val series = result.series[TimeseriesCount]`.
 
+`TopNQuery`, `GroupByQuery` and `TimeSeriesQuery` can also configured using Druid [query context](https://druid.apache.org/docs/latest/querying/query-context.html), 
+such as `timeout`, `queryId` and `groupByStrategy`. All three types of query contain the argument `context` which 
+associates query parameter with they corresponding values. The parameter names can also be accessed 
+by `ing.wbaa.druid.definitions.QueryContext` object. Consider, for example, a timeseries query with custom `query id` 
+and `priority`:
+
+```scala
+TimeSeriesQuery(
+  aggregations = List(
+    CountAggregation(name = "count")
+  ),
+  granularity = GranularityType.Hour,
+  intervals = List("2011-06-01/2017-06-01"),
+  context = Map(
+    QueryContext.QueryId -> "some_custom_id",
+    QueryContext.Priority -> "10"
+  )
+)
+```
+
 ## Druid query language (DQL)
 
 Scruid also provides a rich Scala API for building queries using the fluent pattern.

--- a/docs/dql.md
+++ b/docs/dql.md
@@ -646,4 +646,41 @@ val query: GroupByQuery = DQL
 val response: Future[List[GroupByIsAnonymous]] = query.execute().map(_.list[GroupByIsAnonymous])
 ```
 
+## Query Context
 
+Druid [query context](https://druid.apache.org/docs/latest/querying/query-context.html) is used for various query 
+configuration parameters, e.g., `timeout`, `queryId` and `groupByStrategy`. Query context can be set in `TopNQuery`, 
+`GroupByQuery` and `TimeSeriesQuery` query types. The parameter names can also be accessed by 
+`ing.wbaa.druid.definitions.QueryContext` object. 
+
+Consider, for example, a group-by query with custom `query id` and `priority`:
+
+```scala
+val query: GroupByQuery = DQL
+    .from("wikiticker")
+    .granularity(GranularityType.Day)
+    .interval("2011-06-01/2017-06-01")
+    .agg(count as "count")
+    .where('countryName.isNotNull)
+    .groupBy('isAnonymous, 'countryName.extract(UpperExtractionFn()) as "country")
+    .withQueryContext(Map(
+      QueryContext.QueryId  -> "some_custom_id",
+      QueryContext.Priority -> "100"
+    ))
+    .build()
+```
+
+Alternatively, context parameters can also be specified one each time by using the function `setQueryContextParam`:
+
+```scala
+val query: GroupByQuery = DQL
+    .from("wikiticker")
+    .granularity(GranularityType.Day)
+    .interval("2011-06-01/2017-06-01")
+    .agg(count as "count")
+    .where('countryName.isNotNull)
+    .groupBy('isAnonymous, 'countryName.extract(UpperExtractionFn()) as "country")
+    .setQueryContextParam(QueryContext.QueryId, "some_custom_id")
+    .setQueryContextParam(QueryContext.Priority, "100")
+    .build()
+```

--- a/src/main/scala/ing/wbaa/druid/DruidQuery.scala
+++ b/src/main/scala/ing/wbaa/druid/DruidQuery.scala
@@ -22,6 +22,7 @@ import java.time.ZonedDateTime
 import akka.NotUsed
 import akka.stream.scaladsl.Source
 import ca.mrvisser.sealerate
+import ing.wbaa.druid.definitions.QueryContext.{ QueryContextParam, QueryContextValue }
 import ing.wbaa.druid.definitions._
 import io.circe.generic.auto._
 import io.circe.syntax._
@@ -44,6 +45,7 @@ sealed trait DruidQuery {
   val aggregations: Iterable[Aggregation]
   val filter: Option[Filter]
   val intervals: Iterable[String]
+  val context: Map[String, String]
 
   def execute()(implicit config: DruidConfig = DruidConfig.DefaultConfig): Future[DruidResponse] =
     config.client.doQuery(this)
@@ -82,6 +84,7 @@ sealed trait DruidQuery {
 }
 
 object DruidQuery {
+
   implicit val encoder: Encoder[DruidQuery] = new Encoder[DruidQuery] {
     final def apply(query: DruidQuery): Json =
       (query match {
@@ -102,7 +105,8 @@ case class GroupByQuery(
     granularity: Granularity = GranularityType.All,
     having: Option[Having] = None,
     limitSpec: Option[LimitSpec] = None,
-    postAggregations: Iterable[PostAggregation] = Iterable.empty
+    postAggregations: Iterable[PostAggregation] = Iterable.empty,
+    context: Map[QueryContextParam, QueryContextValue] = Map.empty
 )(implicit val config: DruidConfig = DruidConfig.DefaultConfig)
     extends DruidQuery {
   val queryType          = QueryType.GroupBy
@@ -149,7 +153,8 @@ case class TimeSeriesQuery(
     filter: Option[Filter] = None,
     granularity: Granularity = GranularityType.Week,
     descending: String = "true",
-    postAggregations: Iterable[PostAggregation] = Iterable.empty
+    postAggregations: Iterable[PostAggregation] = Iterable.empty,
+    context: Map[QueryContextParam, QueryContextValue] = Map.empty
 )(implicit val config: DruidConfig = DruidConfig.DefaultConfig)
     extends DruidQuery {
   val queryType          = QueryType.Timeseries
@@ -164,7 +169,8 @@ case class TopNQuery(
     intervals: Iterable[String],
     granularity: Granularity = GranularityType.All,
     filter: Option[Filter] = None,
-    postAggregations: Iterable[PostAggregation] = Iterable.empty
+    postAggregations: Iterable[PostAggregation] = Iterable.empty,
+    context: Map[QueryContextParam, QueryContextValue] = Map.empty
 )(implicit val config: DruidConfig = DruidConfig.DefaultConfig)
     extends DruidQuery {
   val queryType          = QueryType.TopN

--- a/src/main/scala/ing/wbaa/druid/definitions/QueryContext.scala
+++ b/src/main/scala/ing/wbaa/druid/definitions/QueryContext.scala
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ing.wbaa.druid.definitions
+
+object QueryContext {
+
+  type QueryContextParam = String
+  type QueryContextValue = String
+
+  // the following apply only to all queries
+  final val Timeout                      = "timeout"
+  final val Priority                     = "priority"
+  final val QueryId                      = "queryId"
+  final val UseCache                     = "useCache"
+  final val PopulateCache                = "populateCache"
+  final val UseResultLevelCache          = "useResultLevelCache"
+  final val PopulateResultLevelCache     = "populateResultLevelCache"
+  final val BySegment                    = "bySegment"
+  final val Finalize                     = "finalize"
+  final val ChunkPeriod                  = "chunkPeriod"
+  final val MaxScatterGatherBytes        = "maxScatterGatherBytes"
+  final val MaxQueuedBytes               = "maxQueuedBytes"
+  final val SerializeDateTimeAsLong      = "serializeDateTimeAsLong"
+  final val SerializeDateTimeAsLongInner = "serializeDateTimeAsLongInner"
+
+  // the following apply only to time-series queries
+  final val SkipEmptyBuckets = "skipEmptyBuckets"
+  final val GrandTotal       = "grandTotal"
+
+  // the following apply only to top-n queries
+  final val MinTopNThreshold = "minTopNThreshold"
+
+  // the following apply only to group-by queries
+  final val GroupByStrategy         = "groupByStrategy"
+  final val GroupByIsSingleThreaded = "groupByIsSingleThreaded"
+
+  // group-by V2 parameters
+  final val MaxMergingDictionarySize    = "maxMergingDictionarySize"
+  final val MaxOnDiskStorage            = "maxOnDiskStorage"
+  final val BufferGrouperInitialBuckets = "bufferGrouperInitialBuckets"
+  final val BufferGrouperMaxLoadFactor  = "bufferGrouperMaxLoadFactor"
+  final val ForceHashAggregation        = "forceHashAggregation"
+  final val IntermediateCombineDegree   = "intermediateCombineDegree"
+  final val NumParallelCombineThreads   = "numParallelCombineThreads"
+
+  final val SortByDimsFirst    = "sortByDimsFirst"
+  final val ForceLimitPushDown = "forceLimitPushDown"
+
+  // group-by V1 parameters
+  final val MaxIntermediateRows = "maxIntermediateRows"
+  final val MaxResults          = "maxResults"
+  final val UseOffheap          = "useOffheap"
+
+}

--- a/src/main/scala/ing/wbaa/druid/definitions/QueryContext.scala
+++ b/src/main/scala/ing/wbaa/druid/definitions/QueryContext.scala
@@ -23,20 +23,24 @@ object QueryContext {
   type QueryContextValue = String
 
   // the following apply only to all queries
-  final val Timeout                      = "timeout"
-  final val Priority                     = "priority"
-  final val QueryId                      = "queryId"
-  final val UseCache                     = "useCache"
-  final val PopulateCache                = "populateCache"
-  final val UseResultLevelCache          = "useResultLevelCache"
-  final val PopulateResultLevelCache     = "populateResultLevelCache"
-  final val BySegment                    = "bySegment"
-  final val Finalize                     = "finalize"
+  final val Timeout                  = "timeout"
+  final val Priority                 = "priority"
+  final val QueryId                  = "queryId"
+  final val UseCache                 = "useCache"
+  final val PopulateCache            = "populateCache"
+  final val UseResultLevelCache      = "useResultLevelCache"
+  final val PopulateResultLevelCache = "populateResultLevelCache"
+  final val BySegment                = "bySegment"
+  final val Finalize                 = "finalize"
+  @deprecated("deprecated context parameter in Druid")
   final val ChunkPeriod                  = "chunkPeriod"
   final val MaxScatterGatherBytes        = "maxScatterGatherBytes"
   final val MaxQueuedBytes               = "maxQueuedBytes"
   final val SerializeDateTimeAsLong      = "serializeDateTimeAsLong"
   final val SerializeDateTimeAsLongInner = "serializeDateTimeAsLongInner"
+
+  final val Vectorize  = "vectorize"
+  final val VectorSize = "vectorizeSize"
 
   // the following apply only to time-series queries
   final val SkipEmptyBuckets = "skipEmptyBuckets"

--- a/src/test/scala/ing/wbaa/druid/QueryContextSpec.scala
+++ b/src/test/scala/ing/wbaa/druid/QueryContextSpec.scala
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ing.wbaa.druid
+
+import ing.wbaa.druid.definitions._
+import io.circe.generic.auto._
+import io.circe.syntax._
+import org.scalatest._
+import org.scalatest.concurrent._
+import org.scalatest.time._
+
+class QueryContextSpec extends WordSpec with Matchers with ScalaFutures {
+
+  implicit override val patienceConfig =
+    PatienceConfig(timeout = Span(20, Seconds), interval = Span(5, Millis))
+  private val totalNumberOfEntries = 39244
+  implicit val config              = DruidConfig()
+  implicit val mat                 = config.client.actorMaterializer
+
+  case class TimeseriesCount(count: Int)
+
+  "TimeSeriesQuery with context" should {
+
+    "successfully be interpreted by Druid" in {
+
+      val query = TimeSeriesQuery(
+        aggregations = List(
+          CountAggregation(name = "count")
+        ),
+        granularity = GranularityType.Hour,
+        intervals = List("2011-06-01/2017-06-01"),
+        context = Map(
+          QueryContext.QueryId          -> "some_custom_id",
+          QueryContext.Priority         -> "100",
+          QueryContext.UseCache         -> "false",
+          QueryContext.SkipEmptyBuckets -> "true"
+        )
+      )
+
+      val requestJson = query.asJson.noSpaces
+
+      requestJson shouldBe
+      """{"aggregations":[{"name":"count","type":"count"}],"intervals":["2011-06-01/2017-06-01"],"filter":null,"granularity":"hour","descending":"true","postAggregations":[],"context":{"queryId":"some_custom_id","priority":"100","useCache":"false","skipEmptyBuckets":"true"}}"""
+
+      val resultF = query.execute()
+
+      whenReady(resultF) { response =>
+        response.list[TimeseriesCount].map(_.count).sum shouldBe totalNumberOfEntries
+      }
+    }
+
+  }
+
+}


### PR DESCRIPTION
Adds support for passing query context parameters to Druid (see https://druid.apache.org/docs/latest/querying/query-context.html). The query context is used for setting various query configuration parameters and is being represented by a Map[String, String] (parameter name and value).