### PR TITLE
Move to Apache Druid 0.15.1 Docker image for CI

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,13 +3,14 @@ version: "2.0"
 services:
   
   scruid_druid:
-    image: mmartina/docker-druid:latest
+    image: fokkodriesprong/docker-druid
     container_name: scruid_druid
     ports:
       - "8081:8081"
       - "8082:8082"
       - "8083:8082"
       - "8084:8082"
+      - "8888:8888"
 
   delay_response:
     image: andymacdonald/clusterf-chaos-proxy:latest

--- a/services.sh
+++ b/services.sh
@@ -4,7 +4,7 @@
 : ${DRUID_HOST:="localhost"}
 : ${DRUID_PORT:="8082"}
 
-set -ex
+set -e
 
 wait_for_port() {
   local name="$1" host="$2" port="$3"

--- a/services.sh
+++ b/services.sh
@@ -4,6 +4,8 @@
 : ${DRUID_HOST:="localhost"}
 : ${DRUID_PORT:="8082"}
 
+set -ex
+
 wait_for_port() {
   local name="$1" host="$2" port="$3"
   local j=0

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -40,7 +40,7 @@ druid = {
 
   }
 
-  datasource = "wikiticker"
+  datasource = "wikipedia"
   datasource = ${?DRUID_DATASOURCE}
 
   response-parsing-timeout = 5 seconds

--- a/src/main/scala/ing/wbaa/druid/client/DruidHttpClient.scala
+++ b/src/main/scala/ing/wbaa/druid/client/DruidHttpClient.scala
@@ -88,7 +88,6 @@ class DruidHttpClient private (connectionFlow: DruidHttpClient.ConnectionFlowTyp
       .via(connectionFlow)
       .runWith(Sink.head)
       .flatMap(response => handleResponse(response, queryType, druidConfig.responseParsingTimeout))
-
   }
 
   private def createHttpRequest(

--- a/src/main/scala/ing/wbaa/druid/definitions/Aggregation.scala
+++ b/src/main/scala/ing/wbaa/druid/definitions/Aggregation.scala
@@ -138,13 +138,11 @@ trait FilteredAggregation extends Aggregation {
 }
 
 object FilteredAggregation {
-  implicit val encoder: Encoder[FilteredAggregation] = new Encoder[FilteredAggregation] {
-    final def apply(agg: FilteredAggregation): Json =
-      (agg match {
-        case x: InFilteredAggregation       => x.asJsonObject
-        case x: SelectorFilteredAggregation => x.asJsonObject
-      }).add("filter", filterEncoder(agg.filter)).asJson
-  }
+  implicit val encoder: Encoder[FilteredAggregation] = (agg: FilteredAggregation) =>
+    (agg match {
+      case x: InFilteredAggregation       => x.asJsonObject
+      case x: SelectorFilteredAggregation => x.asJsonObject
+    }).add("filter", filterEncoder(agg.filter)).asJson
 }
 
 case class InFilteredAggregation(name: String, filter: InFilter, aggregator: Aggregation)

--- a/src/main/scala/ing/wbaa/druid/definitions/Aggregation.scala
+++ b/src/main/scala/ing/wbaa/druid/definitions/Aggregation.scala
@@ -138,11 +138,13 @@ trait FilteredAggregation extends Aggregation {
 }
 
 object FilteredAggregation {
-  implicit val encoder: Encoder[FilteredAggregation] = (agg: FilteredAggregation) =>
-    (agg match {
-      case x: InFilteredAggregation       => x.asJsonObject
-      case x: SelectorFilteredAggregation => x.asJsonObject
-    }).add("filter", filterEncoder(agg.filter)).asJson
+  implicit val encoder: Encoder[FilteredAggregation] = new Encoder[FilteredAggregation] {
+    final def apply(agg: FilteredAggregation): Json =
+      (agg match {
+        case x: InFilteredAggregation       => x.asJsonObject
+        case x: SelectorFilteredAggregation => x.asJsonObject
+      }).add("filter", filterEncoder(agg.filter)).asJson
+  }
 }
 
 case class InFilteredAggregation(name: String, filter: InFilter, aggregator: Aggregation)

--- a/src/main/scala/ing/wbaa/druid/dql/Dim.scala
+++ b/src/main/scala/ing/wbaa/druid/dql/Dim.scala
@@ -459,6 +459,18 @@ case class Dim private[dql] (name: String,
   // --------------------------------------------------------------------------
 
   /**
+    * Aggregation to count the number of rows
+    *
+    * Please note the count aggregator counts the number of Druid rows, which
+    * does not always reflect the number of raw events ingested. This is because
+    * Apache Druid can be configured to roll up data at ingestion time.
+    *
+    * To count the number of ingested rows of data, include a count aggregator
+    * at ingestion time, and a longSum aggregator at query time.
+    */
+  def count: AggregationExpression = AggregationOps.count
+
+  /**
     * Aggregation to compute the sum of values (as a 64-bit signed integer)
     */
   def longSum: AggregationExpression = AggregationOps.longSum(this)

--- a/src/test/scala/ing/wbaa/druid/DruidQuerySpec.scala
+++ b/src/test/scala/ing/wbaa/druid/DruidQuerySpec.scala
@@ -354,11 +354,11 @@ class DruidQuerySpec extends WordSpec with Matchers with ScalaFutures {
         threshold = 5,
         metric = "count",
         aggregations = List(
-          LongSumAggregation(name = "count", fieldName = "count"),
+          CountAggregation("count"),
           InFilteredAggregation(
-            name = "InFilteredAgg",
+            name = "filteredCount",
             InFilter(dimension = "channel", values = List("#en.wikipedia", "#de.wikipedia")),
-            aggregator = LongSumAggregation(name = "filteredCount", fieldName = "count")
+            aggregator = CountAggregation("filteredCount")
           )
         ),
         intervals = List("2011-06-01/2017-06-01")
@@ -387,11 +387,11 @@ class DruidQuerySpec extends WordSpec with Matchers with ScalaFutures {
         threshold = 5,
         metric = "count",
         aggregations = List(
-          LongSumAggregation(name = "count", fieldName = "count"),
+          CountAggregation("count"),
           SelectorFilteredAggregation(
-            name = "SelectorFilteredAgg",
+            name = "filteredCount",
             SelectFilter(dimension = "channel", value = "#en.wikipedia"),
-            aggregator = LongSumAggregation(name = "filteredCount", fieldName = "count")
+            aggregator = CountAggregation("filteredCount")
           )
         ),
         intervals = List("2011-06-01/2017-06-01")
@@ -419,7 +419,7 @@ class DruidQuerySpec extends WordSpec with Matchers with ScalaFutures {
         threshold = 5,
         metric = "count",
         aggregations = List(
-          LongSumAggregation(name = "count", fieldName = "count")
+          CountAggregation("count")
         ),
         postAggregations = List(
           (FieldAccessPostAggregation("count") / ConstantPostAggregation(2))

--- a/src/test/scala/ing/wbaa/druid/definitions/PostAggregationSpec.scala
+++ b/src/test/scala/ing/wbaa/druid/definitions/PostAggregationSpec.scala
@@ -43,7 +43,7 @@ class PostAggregationSpec extends Matchers with WordSpecLike with ScalaFutures {
   sealed trait TestContext {
     def baseRequest(pas: PostAggregation*): GroupByQuery = GroupByQuery(
       aggregations = List(
-        LongSumAggregation("count", "count"),
+        CountAggregation("count"),
         LongSumAggregation("added", "added"),
         LongSumAggregation("deleted", "deleted")
       ),

--- a/src/test/scala/ing/wbaa/druid/dql/DQLSpec.scala
+++ b/src/test/scala/ing/wbaa/druid/dql/DQLSpec.scala
@@ -157,9 +157,9 @@ class DQLSpec extends WordSpec with Matchers with ScalaFutures {
     "successfully be interpreted by Druid" in {
 
       val query = DQL
-        .agg('count.longSum as "count")
+        .agg('count.count as "count")
         .agg(
-          'channel.inFiltered('count.longSum as "filteredCount", "#en.wikipedia", "#de.wikipedia")
+          'channel.inFiltered('count.count, "#en.wikipedia", "#de.wikipedia") as "filteredCount"
         )
         .interval("2011-06-01/2017-06-01")
         .topN(dimension = 'isAnonymous, metric = "count", threshold = 5)
@@ -185,10 +185,12 @@ class DQLSpec extends WordSpec with Matchers with ScalaFutures {
 
       val query = DQL
         .topN('isAnonymous, metric = "count", threshold = 5)
-        .agg('count.longSum as "count")
+        .agg('count.count as "count")
         .agg(
-          'channel.selectorFiltered(aggregator = 'count.longSum as "filteredCount",
-                                    value = "#en.wikipedia") as "SelectorFilteredAgg"
+          'channel.selectorFiltered(
+            aggregator = 'count.count,
+            value = "#en.wikipedia"
+          ) as "filteredCount"
         )
         .interval("2011-06-01/2017-06-01")
         .build()


### PR DESCRIPTION
I'd like to move to another CI image for Scruid. My major objection is that the [image is pushed by hand](https://hub.docker.com/r/mmartina/docker-druid). I'd prefer it being built by a Dockerhub autobuild, so we actually know from what source the image is built.

Also took the moment to update to Druid 0.15.0. This includes building the Docker image from the Druid binaries and greatly simplifying the Dockerfile: https://github.com/Fokko/docker-druid/commit/45165822c3c353abebed441b9eb3c8c338305ca3
I've opened a PR to the Druid docker image as well: https://github.com/druid-io/docker-druid/pull/72

One thing changed with the Druid update. The predefined `count` [metric has been removed](https://github.com/Fokko/docker-druid/commit/cefde1cb194f90dfd08231c149a60de306d8a4b3#diff-8ff2234341ae5f1f32c166b32fa29782L50-L53), and therefore I had to updates some tests. Instead of posting the JSON ingestion task, I now use the CLI that ships with Druid: https://github.com/Fokko/docker-druid/blob/master/Dockerfile#L17-L18

Going to Druid 0.15.0 also gives us [a nice UI](http://localhost:8888/) to test queries:

![image](https://user-images.githubusercontent.com/1134248/62644134-b6139a80-b949-11e9-8cdd-973270814633.png)

![image](https://user-images.githubusercontent.com/1134248/62644148-c0359900-b949-11e9-87a0-c2c430ff9e5d.png)