### PR TITLE
Add protocol and headers to HttpStatusException

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,3 +35,14 @@ services:
       JAVA_OPTS: "-Dserver.port=8090 -Dchaos.strategy=INTERNAL_SERVER_ERROR -Ddestination.hostProtocolAndPort=http://scruid_druid:8082"
     ports:
       - "8086:8090"
+
+  slow_response:
+    build:
+      context: docker/openresty
+    container_name: slow_response
+    depends_on:
+      - scruid_druid
+    links:
+      - scruid_druid
+    ports:
+      - "8087:8080"

--- a/docker/openresty/Dockerfile
+++ b/docker/openresty/Dockerfile
@@ -1,0 +1,5 @@
+FROM openresty/openresty:1.15.8.2-1-alpine
+
+ADD slow502.conf /etc/nginx/conf.d/slow.conf
+
+EXPOSE 8080

--- a/docker/openresty/README.md
+++ b/docker/openresty/README.md
@@ -1,0 +1,12 @@
+# OpenResty container
+
+Generates an HTTP 502 response, and sends the response body really slowly, so that we can test with
+a response read timeout.
+
+Can be expanded with additional NGINX configuration files if future test cases require other
+OpenResty functions.
+
+## References:
+
+- Docker Hub: [openresty/openresty](https://hub.docker.com/r/openresty/openresty)
+- OpenResty [NGINX echo module](https://github.com/openresty/echo-nginx-module) 

--- a/docker/openresty/slow502.conf
+++ b/docker/openresty/slow502.conf
@@ -1,0 +1,12 @@
+server {
+  listen 8080;
+    
+  location / {
+    default_type application/json;
+    echo_status 502;
+    echo "{";
+    echo_flush;
+    echo_sleep 5;
+    echo "}";
+  }
+}

--- a/services.sh
+++ b/services.sh
@@ -33,7 +33,7 @@ usage() {
 
 case "$1" in
   start)
-    docker-compose up -d 
+    docker-compose up -d --build
     wait_for_port "druid" ${DRUID_HOST} ${DRUID_PORT}
   ;;
   stop)

--- a/src/main/scala/ing/wbaa/druid/client/DruidAdvancedHttpClient.scala
+++ b/src/main/scala/ing/wbaa/druid/client/DruidAdvancedHttpClient.scala
@@ -395,6 +395,7 @@ object DruidAdvancedHttpClient extends DruidClientBuilder {
     require(brokers.nonEmpty)
 
     val settings: ConnectionPoolSettings = ConnectionPoolSettings(connectionPoolConfig)
+    val parallelism                      = settings.pipeliningLimit * settings.maxConnections
     val log: LoggingAdapter              = system.log
 
     brokers.map { queryHost ⇒
@@ -417,7 +418,7 @@ object DruidAdvancedHttpClient extends DruidClientBuilder {
             )
           }
         }
-        .mapAsync(settings.maxOpenRequests) {
+        .mapAsyncUnordered(parallelism) {
           // consider any response with HTTP Code different from StatusCodes.OK as a failure
           case (triedResponse, responsePromise) =>
             triedResponse match {

--- a/src/main/scala/ing/wbaa/druid/client/DruidAdvancedHttpClient.scala
+++ b/src/main/scala/ing/wbaa/druid/client/DruidAdvancedHttpClient.scala
@@ -424,8 +424,8 @@ object DruidAdvancedHttpClient extends DruidClientBuilder {
               case Success(response) if response.status != StatusCodes.OK =>
                 response.entity
                   .toStrict(responseParsingTimeout)
-                  .map(Success(_))
-                  .recover {
+                  .map(Success(_)) // Success[HttpEntity.Strict] --> Success[Try[HttpEntity.Strict]]
+                  .recover { //       Failure[IOException]       --> Success[Try[IOException]]
                     case t: Throwable => Failure(t)
                   }
                   .map((entity: Try[HttpEntity.Strict]) => {

--- a/src/main/scala/ing/wbaa/druid/client/DruidClient.scala
+++ b/src/main/scala/ing/wbaa/druid/client/DruidClient.scala
@@ -141,7 +141,7 @@ trait DruidResponseHandler {
         .recover {
           case t: Throwable => Failure(t)
         }
-        .flatMap { (entity: Try[HttpEntity.Strict]) =>
+        .flatMap { entity: Try[HttpEntity.Strict] =>
           Future.failed(
             new HttpStatusException(response.status, response.protocol, response.headers, entity)
           )

--- a/src/main/scala/ing/wbaa/druid/client/DruidClient.scala
+++ b/src/main/scala/ing/wbaa/druid/client/DruidClient.scala
@@ -137,7 +137,7 @@ trait DruidResponseHandler {
     if (response.status != StatusCodes.OK) {
       body.flatMap { b =>
         Future.failed(
-          new HttpStatusException(response.status, Some(b))
+          new HttpStatusException(response.status, response.protocol, response.headers, b)
         )
       }
     } else {

--- a/src/main/scala/ing/wbaa/druid/client/DruidClient.scala
+++ b/src/main/scala/ing/wbaa/druid/client/DruidClient.scala
@@ -19,7 +19,7 @@ package ing.wbaa.druid.client
 
 import akka.NotUsed
 import akka.actor.ActorSystem
-import akka.http.scaladsl.model.{ HttpResponse, StatusCodes }
+import akka.http.scaladsl.model.{ HttpEntity, HttpResponse, StatusCodes }
 import akka.stream.ActorMaterializer
 import akka.stream.scaladsl._
 import ing.wbaa.druid._
@@ -32,6 +32,7 @@ import org.typelevel.jawn.AsyncParser
 
 import scala.concurrent.{ ExecutionContextExecutor, Future }
 import scala.concurrent.duration.FiniteDuration
+import scala.util.{ Failure, Success, Try }
 
 trait DruidClient extends CirceHttpSupport with JavaTimeDecoders {
 
@@ -135,11 +136,16 @@ trait DruidResponseHandler {
     body.onComplete(b => logger.debug(s"Druid response: $b"))
 
     if (response.status != StatusCodes.OK) {
-      body.flatMap { b =>
-        Future.failed(
-          new HttpStatusException(response.status, response.protocol, response.headers, b)
-        )
-      }
+      body
+        .map(Success(_))
+        .recover {
+          case t: Throwable => Failure(t)
+        }
+        .flatMap { (entity: Try[HttpEntity.Strict]) =>
+          Future.failed(
+            new HttpStatusException(response.status, response.protocol, response.headers, entity)
+          )
+        }
     } else {
       body
         .map(e => e.data.decodeString("UTF-8"))

--- a/src/main/scala/ing/wbaa/druid/client/HttpStatusException.scala
+++ b/src/main/scala/ing/wbaa/druid/client/HttpStatusException.scala
@@ -16,7 +16,9 @@
  */
 package ing.wbaa.druid.client
 
-import akka.http.scaladsl.model.{ HttpEntity, HttpHeader, HttpProtocol, StatusCode }
+import akka.http.scaladsl.model.{ HttpEntity, HttpHeader, HttpProtocol, HttpResponse, StatusCode }
+
+import scala.collection.immutable.Seq
 
 /**
   * Indicates that Druid returned a non-OK HTTP status code.
@@ -37,4 +39,7 @@ class HttpStatusException(val status: StatusCode,
                           val protocol: HttpProtocol,
                           val headers: Seq[HttpHeader],
                           val entity: HttpEntity.Strict)
-    extends IllegalStateException(s"Received response with HTTP status code $status")
+    extends IllegalStateException(s"Received response with HTTP status code $status") {
+
+  def response: HttpResponse = HttpResponse(status, headers, entity, protocol)
+}

--- a/src/main/scala/ing/wbaa/druid/client/HttpStatusException.scala
+++ b/src/main/scala/ing/wbaa/druid/client/HttpStatusException.scala
@@ -16,19 +16,25 @@
  */
 package ing.wbaa.druid.client
 
-import akka.http.scaladsl.model.{ HttpEntity, StatusCode }
+import akka.http.scaladsl.model.{ HttpEntity, HttpHeader, HttpProtocol, StatusCode }
 
 /**
   * Indicates that Druid returned a non-OK HTTP status code.
   *
   * Note: the response entity is eagerly loaded (`HttpEntity.Strict`). I chose to do so because
   * having to drain or discard a stream on an exception object violates the Principle of Least
-  * Surprise.
+  * Surprise. This class does not simply embed the `HttpResponse` because I found no way to
+  * expose the (eager loaded) fields without requiring an execution context.
   *
   * This class extends IllegalStateException to maintain backwards compatibility.
   *
   * @param status the response status.
+  * @param protocol the response protocol.
+  * @param headers the response headers.
   * @param entity the response entity.
   */
-class HttpStatusException(val status: StatusCode, val entity: Option[HttpEntity.Strict])
-    extends IllegalStateException(s"Received response with HTTP status code $status") {}
+class HttpStatusException(val status: StatusCode,
+                          val protocol: HttpProtocol,
+                          val headers: Seq[HttpHeader],
+                          val entity: HttpEntity.Strict)
+    extends IllegalStateException(s"Received response with HTTP status code $status")

--- a/src/main/scala/ing/wbaa/druid/client/HttpStatusException.scala
+++ b/src/main/scala/ing/wbaa/druid/client/HttpStatusException.scala
@@ -19,6 +19,7 @@ package ing.wbaa.druid.client
 import akka.http.scaladsl.model.{ HttpEntity, HttpHeader, HttpProtocol, HttpResponse, StatusCode }
 
 import scala.collection.immutable.Seq
+import scala.util.Try
 
 /**
   * Indicates that Druid returned a non-OK HTTP status code.
@@ -38,8 +39,8 @@ import scala.collection.immutable.Seq
 class HttpStatusException(val status: StatusCode,
                           val protocol: HttpProtocol,
                           val headers: Seq[HttpHeader],
-                          val entity: HttpEntity.Strict)
+                          val entity: Try[HttpEntity.Strict])
     extends IllegalStateException(s"Received response with HTTP status code $status") {
 
-  def response: HttpResponse = HttpResponse(status, headers, entity, protocol)
+  def response: HttpResponse = HttpResponse(status, headers, entity.get, protocol)
 }

--- a/src/main/scala/ing/wbaa/druid/client/HttpStatusException.scala
+++ b/src/main/scala/ing/wbaa/druid/client/HttpStatusException.scala
@@ -42,5 +42,12 @@ class HttpStatusException(val status: StatusCode,
                           val entity: Try[HttpEntity.Strict])
     extends IllegalStateException(s"Received response with HTTP status code $status") {
 
+  /**
+    * Returns an `HttpResponse` object equivalent to the original response received from Druid.
+    *
+    * Caution: this method throws an exception if `this.entity` is a failure.
+    * @return an HTTP response object.
+    * @throws Throwable if the response entity `toStrict` failed.
+    */
   def response: HttpResponse = HttpResponse(status, headers, entity.get, protocol)
 }

--- a/src/test/scala/ing/wbaa/druid/DruidAdvancedHttpClientSpec.scala
+++ b/src/test/scala/ing/wbaa/druid/DruidAdvancedHttpClientSpec.scala
@@ -142,7 +142,7 @@ class DruidAdvancedHttpClientSpec extends WordSpec with Matchers with ScalaFutur
           exception.status shouldBe StatusCodes.InternalServerError
           exception.protocol shouldBe HttpProtocols.`HTTP/1.1`
           exception.headers should contain(new RawHeader("x-clusterfk-status-code", "500"))
-          exception.entity.isKnownEmpty() shouldBe true
+          exception.entity.get.isKnownEmpty() shouldBe true
 
           exception.response.status shouldBe StatusCodes.InternalServerError
         case response => fail(s"expected HttpStatusException, got $response")

--- a/src/test/scala/ing/wbaa/druid/DruidAdvancedHttpClientSpec.scala
+++ b/src/test/scala/ing/wbaa/druid/DruidAdvancedHttpClientSpec.scala
@@ -18,7 +18,7 @@
 package ing.wbaa.druid
 
 import akka.http.scaladsl.model.headers.RawHeader
-import akka.http.scaladsl.model.{ HttpProtocols, StatusCode }
+import akka.http.scaladsl.model.{ HttpProtocols, StatusCodes }
 import ing.wbaa.druid.client.{ DruidAdvancedHttpClient, HttpStatusException }
 import ing.wbaa.druid.definitions._
 import org.scalatest._
@@ -139,10 +139,12 @@ class DruidAdvancedHttpClientSpec extends WordSpec with Matchers with ScalaFutur
 
       whenReady(responseFuture.failed) {
         case exception: HttpStatusException =>
-          exception.status shouldBe StatusCode.int2StatusCode(500)
+          exception.status shouldBe StatusCodes.InternalServerError
           exception.protocol shouldBe HttpProtocols.`HTTP/1.1`
           exception.headers should contain(new RawHeader("x-clusterfk-status-code", "500"))
           exception.entity.isKnownEmpty() shouldBe true
+
+          exception.response.status shouldBe StatusCodes.InternalServerError
         case response => fail(s"expected HttpStatusException, got $response")
       }
 

--- a/src/test/scala/ing/wbaa/druid/DruidAdvancedHttpClientSpec.scala
+++ b/src/test/scala/ing/wbaa/druid/DruidAdvancedHttpClientSpec.scala
@@ -17,7 +17,8 @@
 
 package ing.wbaa.druid
 
-import akka.http.scaladsl.model.StatusCode
+import akka.http.scaladsl.model.headers.RawHeader
+import akka.http.scaladsl.model.{ HttpProtocols, StatusCode }
 import ing.wbaa.druid.client.{ DruidAdvancedHttpClient, HttpStatusException }
 import ing.wbaa.druid.definitions._
 import org.scalatest._
@@ -139,10 +140,9 @@ class DruidAdvancedHttpClientSpec extends WordSpec with Matchers with ScalaFutur
       whenReady(responseFuture.failed) {
         case exception: HttpStatusException =>
           exception.status shouldBe StatusCode.int2StatusCode(500)
-          exception.entity match {
-            case Some(entity) => entity.isKnownEmpty() shouldBe true
-            case _            => fail("expected empty entity, got empty option")
-          }
+          exception.protocol shouldBe HttpProtocols.`HTTP/1.1`
+          exception.headers should contain(new RawHeader("x-clusterfk-status-code", "500"))
+          exception.entity.isKnownEmpty() shouldBe true
         case response => fail(s"expected HttpStatusException, got $response")
       }
 

--- a/src/test/scala/ing/wbaa/druid/DruidClientSpec.scala
+++ b/src/test/scala/ing/wbaa/druid/DruidClientSpec.scala
@@ -26,7 +26,6 @@ import org.scalatest.concurrent._
 
 import scala.concurrent.duration._
 import scala.language.postfixOps
-import scala.util.Success
 
 class DruidClientSpec extends WordSpec with Matchers with ScalaFutures {
 

--- a/src/test/scala/ing/wbaa/druid/DruidClientSpec.scala
+++ b/src/test/scala/ing/wbaa/druid/DruidClientSpec.scala
@@ -82,7 +82,7 @@ class DruidClientSpec extends WordSpec with Matchers with ScalaFutures {
           exception.status shouldBe StatusCodes.InternalServerError
           exception.protocol shouldBe HttpProtocols.`HTTP/1.1`
           exception.headers should contain(new RawHeader("x-clusterfk-status-code", "500"))
-          exception.entity.isKnownEmpty() shouldBe true
+          exception.entity.get.isKnownEmpty() shouldBe true
         case response => fail(s"expected HttpStatusException, got $response")
       }
 

--- a/src/test/scala/ing/wbaa/druid/DruidClientSpec.scala
+++ b/src/test/scala/ing/wbaa/druid/DruidClientSpec.scala
@@ -18,7 +18,7 @@
 package ing.wbaa.druid
 
 import akka.http.scaladsl.model.headers.RawHeader
-import akka.http.scaladsl.model.{ HttpProtocols, StatusCode }
+import akka.http.scaladsl.model.{ HttpProtocols, StatusCodes }
 import ing.wbaa.druid.client.{ DruidHttpClient, HttpStatusException }
 import ing.wbaa.druid.definitions.{ CountAggregation, GranularityType }
 import org.scalatest._
@@ -79,7 +79,7 @@ class DruidClientSpec extends WordSpec with Matchers with ScalaFutures {
 
       whenReady(responseFuture.failed) {
         case exception: HttpStatusException =>
-          exception.status shouldBe StatusCode.int2StatusCode(500)
+          exception.status shouldBe StatusCodes.InternalServerError
           exception.protocol shouldBe HttpProtocols.`HTTP/1.1`
           exception.headers should contain(new RawHeader("x-clusterfk-status-code", "500"))
           exception.entity.isKnownEmpty() shouldBe true

--- a/src/test/scala/ing/wbaa/druid/DruidClientSpec.scala
+++ b/src/test/scala/ing/wbaa/druid/DruidClientSpec.scala
@@ -17,6 +17,8 @@
 
 package ing.wbaa.druid
 
+import java.util.concurrent.TimeoutException
+
 import akka.http.scaladsl.model.headers.RawHeader
 import akka.http.scaladsl.model.{ HttpProtocols, StatusCodes }
 import ing.wbaa.druid.client.{ DruidHttpClient, HttpStatusException }
@@ -86,6 +88,37 @@ class DruidClientSpec extends WordSpec with Matchers with ScalaFutures {
       }
 
       client.shutdown().futureValue
+    }
+
+    "throw HttpStatusException for non-200 status codes where body fails to materialize" in {
+      // the endpoint on 8087 returns HTTP 502 and takes 5 seconds to send the response body
+      implicit val config =
+        DruidConfig(
+          clientBackend = classOf[DruidHttpClient],
+          responseParsingTimeout = 1.seconds,
+          hosts = Seq(QueryHost("localhost", 8087))
+        )
+
+      val client = config.client
+      val responseFuture = client.doQuery(
+        TimeSeriesQuery(
+          aggregations = List(
+            CountAggregation(name = "count")
+          ),
+          granularity = GranularityType.Hour,
+          intervals = List("2011-06-01/2017-06-01")
+        )
+      )
+
+      whenReady(responseFuture.failed) {
+        case exception: HttpStatusException =>
+          exception.status shouldBe StatusCodes.BadGateway
+          exception.entity.isFailure shouldBe true
+          exception.entity.failed.get shouldBe a[TimeoutException]
+        case response => fail(s"expected HttpStatusException, got $response")
+      }
+
+      config.client.shutdown().futureValue
     }
 
   }


### PR DESCRIPTION
This is an improvement to my earlier PR #67. I realised that I had forgotten to include the response headers in the `HttpStatusException`. While making the change, I decided to also add the protocol, which is the only other field in `HttpResponse`.

I did not simply embed `HttpResponse` because `HttpResponse.toStrict` doesn't change the object type the way `HttpEntity.toStrict` does. This means that there was no way (that I can find) to make the exception fields accessible without having to provide all the async context.

Finally, this commit changes the `Option[HttpEntity.Strict]` in the exception type to a `Try[HttpEntity.Strict]`. This ensures that if an exception occurs while reading the response body, neither the non-200 status code nor this exception are lost.

All unit tests pass.