### PR TITLE
Adds support for cardinality aggregation

### DIFF
--- a/docs/dql.md
+++ b/docs/dql.md
@@ -399,7 +399,7 @@ doubleLast('dim_name) as "agg_last"
 
 #### Approximate Aggregations
 
-DQL supports `thetaSketch` and `hyperUnique` approximate aggregators.
+DQL supports `thetaSketch`, `hyperUnique` and `cardinality` approximate aggregators.
 
 ```scala
 // can be defined over some dimension
@@ -415,8 +415,51 @@ thetaSketch('dim_name).set(isInputThetaSketch = true, size = 32768) as "agg_thet
 'dim_name.hyperUnique.set(isInputHyperUnique = true, isRound = true) as "agg_hyper_unique"
 ```
 
-#### Filtered Aggregator
+Cardinality aggregator computes the cardinality of a set of dimensions, using HyperLogLog to estimate the cardinality.
+Please note that this aggregator is much slower than indexing a column with the `hyperUnique` aggregator (for details
+see [the official documentation](https://druid.apache.org/docs/latest/querying/hll-old.html)).
 
+By default, cardinality is computed by value.
+
+```scala
+// Compute the cardinality by value for dimensions din_name_one, dim_name_two and dim_name_three
+cardinality('dim_name_one, 'dim_name_two, 'dim_name_three)
+
+// The HyperLogLog algorithm generates decimal estimates with some error. Flag "round" can be set to true to 
+// round off estimated values to whole numbers.
+cardinality('dim_name_one, 'dim_name_two, 'dim_name_three).setRound(true)
+
+// or alternatively
+cardinality('dim_name_one, 'dim_name_two, 'dim_name_three).set(round = true)
+```
+
+Cardinality can also be computed by row, i.e. the cardinality of distinct dimension combinations.
+
+```scala
+// Compute the cardinality by row for dimensions din_name_one, dim_name_two and dim_name_three
+cardinality('dim_name_one, 'dim_name_two, 'dim_name_three).byRow(true)
+
+// or alternatively
+cardinality('dim_name_one, 'dim_name_two, 'dim_name_three).set(byRow = true)
+
+// Similar to cardinality by value the flag "round" can be set to true to 
+// round off estimated values to whole numbers
+cardinality('dim_name_one, 'dim_name_two, 'dim_name_three).byRow(true).setRound(true)
+
+// or alternatively
+cardinality('dim_name_one, 'dim_name_two, 'dim_name_three).set(byRow = true, round = true)
+```
+
+Cardinality can also be computed over the outcomes of any extraction function to some dimension(s). For example,
+assume that we would like to compute the cardinality over the values of `dim_name_one`, `dim_name_two` and the 
+first character over the values of `dim_name_three`. In such case we can use the `SubstringExtractionFn` in 
+cardinality aggregation as below:
+
+```scala
+cardinality('dim_name_one, 'dim_name_two, 'dim_name_three.extract(SubstringExtractionFn(0, Some(1))).as("dim_name_three_first_char"))
+```
+
+#### Filtered Aggregator
 
 `inFiltered` wraps any given aggregator, but only aggregates the values for which the given dimension the *in filter* matches
 Similarly, `selectorFiltered` wraps any given aggregator and filters the values using the *selector filter*.

--- a/docs/dql.md
+++ b/docs/dql.md
@@ -422,7 +422,7 @@ see [the official documentation](https://druid.apache.org/docs/latest/querying/h
 By default, cardinality is computed by value.
 
 ```scala
-// Compute the cardinality by value for dimensions din_name_one, dim_name_two and dim_name_three
+// Compute the cardinality by value for dimensions dim_name_one, dim_name_two and dim_name_three
 cardinality('dim_name_one, 'dim_name_two, 'dim_name_three)
 
 // The HyperLogLog algorithm generates decimal estimates with some error. Flag "round" can be set to true to 
@@ -436,7 +436,7 @@ cardinality('dim_name_one, 'dim_name_two, 'dim_name_three).set(round = true)
 Cardinality can also be computed by row, i.e. the cardinality of distinct dimension combinations.
 
 ```scala
-// Compute the cardinality by row for dimensions din_name_one, dim_name_two and dim_name_three
+// Compute the cardinality by row for dimensions dim_name_one, dim_name_two and dim_name_three
 cardinality('dim_name_one, 'dim_name_two, 'dim_name_three).byRow(true)
 
 // or alternatively

--- a/src/main/scala/ing/wbaa/druid/definitions/Aggregation.scala
+++ b/src/main/scala/ing/wbaa/druid/definitions/Aggregation.scala
@@ -40,6 +40,7 @@ object AggregationType extends EnumCodec[AggregationType] {
   case object LongLast    extends AggregationType
   case object ThetaSketch extends AggregationType
   case object HyperUnique extends AggregationType
+  case object Cardinality extends AggregationType
   case object Filtered    extends AggregationType
   val values: Set[AggregationType] = sealerate.values[AggregationType]
 }
@@ -54,6 +55,7 @@ object Aggregation {
     final def apply(agg: Aggregation): Json =
       (agg match {
         case x: CountAggregation       => x.asJsonObject
+        case x: CardinalityAggregation => x.asJsonObject
         case x: SingleFieldAggregation => x.asJson.asObject.get
         case x: FilteredAggregation    => x.asJson.asObject.get
       }).add("type", agg.`type`.asJson).asJson
@@ -129,6 +131,15 @@ case class HyperUniqueAggregation(
     round: Boolean = false
 ) extends SingleFieldAggregation {
   val `type` = AggregationType.HyperUnique
+}
+
+case class CardinalityAggregation(
+    override val name: String,
+    fields: Iterable[Dimension],
+    byRow: Boolean = false,
+    round: Boolean = false
+) extends Aggregation {
+  override val `type`: AggregationType = AggregationType.Cardinality
 }
 
 trait FilteredAggregation extends Aggregation {

--- a/src/main/scala/ing/wbaa/druid/dql/Operators.scala
+++ b/src/main/scala/ing/wbaa/druid/dql/Operators.scala
@@ -59,6 +59,9 @@ trait AggregationOps {
 
   def hyperUnique(dim: Dim): HyperUniqueAgg = hyperUnique(dim.name)
 
+  def cardinality(dims: Dim*): CardinalityAgg               = CardinalityAgg(dims)
+  def cardinality(name: String, dims: Dim*): CardinalityAgg = CardinalityAgg(dims, Option(name))
+
   def inFiltered(dimName: String,
                  aggregator: AggregationExpression,
                  values: Iterable[String]): InFilteredAgg =

--- a/src/main/scala/ing/wbaa/druid/dql/expressions/Aggregation.scala
+++ b/src/main/scala/ing/wbaa/druid/dql/expressions/Aggregation.scala
@@ -18,6 +18,7 @@
 package ing.wbaa.druid.dql.expressions
 
 import ing.wbaa.druid.definitions._
+import ing.wbaa.druid.dql.Dim
 
 sealed trait AggregationExpression extends Named[AggregationExpression] {
 
@@ -208,6 +209,32 @@ final case class HyperUniqueAgg(fieldName: String,
     copy(isInputHyperUnique = isInputHyperUnique, round = isRound)
 
   override def getName: String = name.getOrElse(s"hyper_unique_$fieldName")
+}
+
+final case class CardinalityAgg(fields: Seq[Dim],
+                                name: Option[String] = None,
+                                byRow: Boolean = false,
+                                round: Boolean = false)
+    extends AggregationExpression {
+
+  override protected[dql] def build(): Aggregation = CardinalityAggregation(
+    this.getName,
+    fields.map(_.build()),
+    byRow,
+    round
+  )
+
+  override def alias(name: String): AggregationExpression = copy(name = Option(name))
+
+  override def getName: String = name.getOrElse(s"cardinality_${fields.map(_.name).mkString("_")}")
+
+  def setByRow(v: Boolean): CardinalityAgg = copy(byRow = v)
+
+  def setRound(v: Boolean): CardinalityAgg = copy(round = v)
+
+  def set(byRow: Boolean = false, round: Boolean = false): CardinalityAgg =
+    copy(byRow = byRow, round = round)
+
 }
 
 final case class InFilteredAgg(dimension: String,


### PR DESCRIPTION
  - adds the corresponding definition in Scruid
  - adds DQL support (operators and expressions)
  - unit tests with cardinality aggregation by value, by row and with extraction function
  - updates DQL documentation regarding cardinality aggregation with examples

GH-73