### PR TITLE
Adds Javascript aggregator and post-aggregator

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: "2.0"
 services:
 
   scruid_druid:
-    image: fokkodriesprong/docker-druid
+    image: fokkodriesprong/docker-druid:latest
     container_name: scruid_druid
     ports:
       - "8081:8081"

--- a/docs/dql.md
+++ b/docs/dql.md
@@ -501,7 +501,7 @@ lengths of the values of `dim_one` and `dim_one` when they are not null:
 ```scala
 javascript(
   name = "length_sum",
-  fieldNames = Seq("dim_one", "dim_two"),
+  fields = Seq('dim_one, 'dim_two), // or the string names of the dimensions (i.e. Seq("dim_one", "dim_two"))  
   fnAggregate = 
     """
     |function (current, dim_one, dim_two) {
@@ -591,6 +591,19 @@ Is used to wrap a hyperUnique object such that it can be used in post aggregatio
 
 // or alternatively as function:
 hyperUniqueCardinality('dim_name)
+```
+
+#### Javascript post-aggregator
+
+Applies the specified Javascript function to the given fields. Fields are passed as arguments to the Javascript 
+function in the given order.
+
+```scala
+// calculate the sum of two dimensions (dim_one and dim_two)
+javascript(name = "sum", fields = Seq('dim_one, 'dim_two), function = "function(dim_one, dim_two) { return dim_one + dim_two; }")
+
+// or alternatively by specifying the dimensions names
+javascript(name = "sum", fields = Seq("dim_one", "dim_two"), function = "function(dim_one, dim_two) { return dim_one + dim_two; }")
 ```
 
 

--- a/docs/dql.md
+++ b/docs/dql.md
@@ -486,6 +486,39 @@ selectorFiltered('channel, 'count.longSum, "#en.wikipedia")
 
 ```
 
+## Javascript Aggregator
+
+Custom aggregations over a set of columns can be defined using Javascript (both metrics and dimensions are allowed).
+The Javascript functions should always return floating-point values. Please note that Javascript-based functionality 
+is disabled by default in Druid server and should be enabled by setting the configuration property 
+`druid.javascript.enabled = true`. For further details see the official Druid  
+[documentation for aggregations](https://druid.apache.org/docs/latest/querying/aggregations) and 
+the [Javascript guide](https://druid.apache.org/docs/latest/development/javascript.html).
+
+Javascript aggregation is defined using the `javascript` function. For example the aggregation below sums the 
+lengths of the values of `dim_one` and `dim_one` when they are not null:
+
+```scala
+javascript(
+  name = "length_sum",
+  fieldNames = Seq("dim_one", "dim_two"),
+  fnAggregate = 
+    """
+    |function (current, dim_one, dim_two) {
+    |  return ((dim_one != null && dim_two != null) ? current + dim_one.length + dim_two.length : current); 
+    |}
+    """.stripMargin,
+  fnCombine = "function(partialA, partialB) { return partialA + partialB; }",
+  fnReset = "function() { return 0; }"
+)
+``` 
+
+The resulting value of the aggregation will be represented by the column `length_sum`. The aggregation is computed over 
+the dimensions `dim_one` and `dim_two` using three Javascript functions. `fnAggregate` defines the partial aggregation 
+update function between `dim_one`, `dim_two` and the current value `current`. `fnCombine` defines how partial 
+aggregation results are being combined. Finally, `fnReset` defines the initial value of the aggregation.
+
+
 ## Post-aggregations
 
 Post-aggregations are specifications of processing that should happen on aggregated values as they come out of Druid.

--- a/src/main/scala/ing/wbaa/druid/definitions/Aggregation.scala
+++ b/src/main/scala/ing/wbaa/druid/definitions/Aggregation.scala
@@ -42,6 +42,7 @@ object AggregationType extends EnumCodec[AggregationType] {
   case object HyperUnique extends AggregationType
   case object Cardinality extends AggregationType
   case object Filtered    extends AggregationType
+  case object Javascript  extends AggregationType
   val values: Set[AggregationType] = sealerate.values[AggregationType]
 }
 
@@ -56,6 +57,7 @@ object Aggregation {
       (agg match {
         case x: CountAggregation       => x.asJsonObject
         case x: CardinalityAggregation => x.asJsonObject
+        case x: JavascriptAggregation  => x.asJsonObject
         case x: SingleFieldAggregation => x.asJson.asObject.get
         case x: FilteredAggregation    => x.asJson.asObject.get
       }).add("type", agg.`type`.asJson).asJson
@@ -162,3 +164,14 @@ case class InFilteredAggregation(name: String, filter: InFilter, aggregator: Agg
     extends FilteredAggregation
 case class SelectorFilteredAggregation(name: String, filter: SelectFilter, aggregator: Aggregation)
     extends FilteredAggregation
+
+case class JavascriptAggregation(
+    override val name: String,
+    fieldNames: Iterable[String],
+    fnAggregate: String,
+    fnCombine: String,
+    fnReset: String
+) extends Aggregation {
+  override val `type`: AggregationType = AggregationType.Javascript
+
+}

--- a/src/main/scala/ing/wbaa/druid/dql/DSL.scala
+++ b/src/main/scala/ing/wbaa/druid/dql/DSL.scala
@@ -38,6 +38,9 @@ object DSL
     */
   implicit def symbolToDim(s: Symbol): Dim = new Dim(s.name)
 
+  implicit def symbolsToDims[T <: Iterable[Symbol]](iterable: T): Iterable[Dim] =
+    iterable.map(s => new Dim(s.name))
+
   implicit class StringToDim(val sc: StringContext) extends AnyVal {
 
     /**

--- a/src/main/scala/ing/wbaa/druid/dql/Operators.scala
+++ b/src/main/scala/ing/wbaa/druid/dql/Operators.scala
@@ -105,6 +105,14 @@ trait AggregationOps {
     SelectorFilteredAgg(dim.name, None, aggregator.build())
 
   def count: CountAgg = new CountAgg()
+
+  def javascript(name: String,
+                 fieldNames: Iterable[String],
+                 fnAggregate: String,
+                 fnCombine: String,
+                 fnReset: String): JavascriptAgg =
+    JavascriptAgg(fieldNames.toSeq, fnAggregate, fnCombine, fnReset, Option(name))
+
 }
 
 trait FilteringExpressionOps {

--- a/src/main/scala/ing/wbaa/druid/dql/Operators.scala
+++ b/src/main/scala/ing/wbaa/druid/dql/Operators.scala
@@ -20,6 +20,8 @@ package ing.wbaa.druid.dql
 import ing.wbaa.druid.definitions.{ ExtractionFn, Filter }
 import ing.wbaa.druid.dql.expressions._
 
+import scala.reflect.ClassTag
+
 trait AggregationOps {
 
   def longSum(dimName: String): LongSumAgg = new LongSumAgg(dimName)
@@ -107,11 +109,18 @@ trait AggregationOps {
   def count: CountAgg = new CountAgg()
 
   def javascript(name: String,
-                 fieldNames: Iterable[String],
+                 fields: Iterable[Dim],
+                 fnAggregate: String,
+                 fnCombine: String,
+                 fnReset: String)(implicit classTag: ClassTag[Dim]): JavascriptAgg =
+    JavascriptAgg(fields.map(_.name).toSeq, fnAggregate, fnCombine, fnReset, Option(name))
+
+  def javascript(name: String,
+                 fields: Iterable[String],
                  fnAggregate: String,
                  fnCombine: String,
                  fnReset: String): JavascriptAgg =
-    JavascriptAgg(fieldNames.toSeq, fnAggregate, fnCombine, fnReset, Option(name))
+    JavascriptAgg(fields.toSeq, fnAggregate, fnCombine, fnReset, Option(name))
 
 }
 
@@ -143,6 +152,16 @@ trait PostAggregationOps {
 
   def hyperUniqueCardinality(dim: Dim): PostAggregationExpression =
     HyperUniqueCardinalityPostAgg(dim.name, dim.outputNameOpt)
+
+  def javascript(name: String,
+                 fields: Iterable[String],
+                 function: String): PostAggregationExpression =
+    JavascriptPostAgg(fields.toSeq, function, Option(name))
+
+  def javascript(name: String, fields: Iterable[Dim], function: String)(
+      implicit classTag: ClassTag[Dim]
+  ): PostAggregationExpression =
+    JavascriptPostAgg(fields.map(_.name).toSeq, function, Option(name))
 }
 
 object AggregationOps         extends AggregationOps

--- a/src/main/scala/ing/wbaa/druid/dql/expressions/Aggregation.scala
+++ b/src/main/scala/ing/wbaa/druid/dql/expressions/Aggregation.scala
@@ -272,3 +272,24 @@ final case class SelectorFilteredAgg(dimension: String,
 
   override def getName: String = name.getOrElse(s"selector_filtered_$dimension")
 }
+
+final case class JavascriptAgg(
+    fields: Seq[String],
+    fnAggregate: String,
+    fnCombine: String,
+    fnReset: String,
+    name: Option[String] = None
+) extends AggregationExpression {
+
+  override protected[dql] def build(): Aggregation = JavascriptAggregation(
+    this.getName,
+    fields,
+    fnAggregate,
+    fnCombine,
+    fnReset
+  )
+
+  override def alias(name: String): AggregationExpression = copy(name = Option(name))
+
+  override def getName: String = name.getOrElse(s"js_${fields.mkString("_")}")
+}

--- a/src/main/scala/ing/wbaa/druid/dql/expressions/PostAggregation.scala
+++ b/src/main/scala/ing/wbaa/druid/dql/expressions/PostAggregation.scala
@@ -88,3 +88,14 @@ case class HyperUniqueCardinalityPostAgg(fieldName: String, name: Option[String]
 
   override def getName: String = name.getOrElse(s"post_${fieldName}")
 }
+
+case class JavascriptPostAgg(fieldNames: Seq[String], function: String, name: Option[String] = None)
+    extends PostAggregationExpression {
+
+  override protected[dql] def build(complexAggNames: Set[String]): PostAggregation =
+    JavascriptPostAggregation(this.getName, fieldNames, function)
+
+  override def alias(name: String): PostAggregationExpression = copy(name = Option(name))
+
+  override def getName: String = name.getOrElse(s"post_${fieldNames.mkString("_")}")
+}


### PR DESCRIPTION
  - adds Javascript aggregator definition in Scruid
  - adds DQL support (operators and expressions) for Javascript aggregator
  - adds Javascript post-aggregator in DQL
  - updates unit tests
  - updates DQL documentation regarding Javascript (post)aggregator with example

GH-72