### PR TITLE
Fix docker-druid on Apache Druid v0.15.1

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: "2.0"
 services:
 
   scruid_druid:
-    image: fokkodriesprong/docker-druid:v0.15.1
+    image: fokkodriesprong/docker-druid:version-0.15.1
     container_name: scruid_druid
     ports:
       - "8081:8081"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: "2.0"
 services:
 
   scruid_druid:
-    image: fokkodriesprong/docker-druid:latest
+    image: fokkodriesprong/docker-druid:v0.15.1
     container_name: scruid_druid
     ports:
       - "8081:8081"


### PR DESCRIPTION
I've created a tag in docker-druid to fix it to Druid 0.15.1: https://github.com/Fokko/docker-druid/releases.

Yesterday Apache Druid 0.16.0 has been released: https://github.com/apache/incubator-druid/releases/tag/druid-0.16.0-incubating

I'd like to bump the CI image to 0.16.0 as well: https://github.com/Fokko/docker-druid/pull/6 Before we merge aht one, we should have merged this PR.

Cheers, Fokko