### PR TITLE
Adds support for Select, Scan and Search queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,8 @@ query representation.
 For example the following:
 
 ```scala
+import ing.wbaa.druid.dql.DSL._
+
 val query: TopNQuery = DQL
     .from("wikipedia")
     .agg(count as "count")

--- a/build.sbt
+++ b/build.sbt
@@ -98,7 +98,7 @@ lazy val root = (project in file("."))
   .settings(commonSettings)
   .settings(
     name := "scruid",
-    version := "2.3.0",
+    version := "2.3.1-SNAPSHOT",
     resolvers += Resolver.sonatypeRepo("releases"),
     libraryDependencies ++= Seq(
       "com.typesafe"           % "config"                   % typesafeConfigVersion,

--- a/docs/dql.md
+++ b/docs/dql.md
@@ -3,16 +3,18 @@
 Scruid provides a rich Scala API for building queries using the fluent pattern.
 
 In order to use DQL, you have to import `ing.wbaa.druid.dql.DSL._` and thereafter build a query using the `DQL` query
-builder. The type of the query can be time-series (default), group-by or top-n.
+builder. The type of the query can be time-series, group-by, top-n, select, scan or search.
 
-For all three types of queries you can define the following:
+For all any type of queries you can define the following:
 
  - The datasource name to perform the query, or defaults to the one that has been defined in the configuration.
  - The granularity of the query, e.g., `Hour`, `Day`, `Week`, etc (default is `Week` for time-series and `All`
  for top-n and group-by).
  - The interval of the query, expressed as [ISO-8601 intervals](https://en.wikipedia.org/wiki/ISO_8601).
- - Filter dimensions
- - Aggregations and post-aggregations
+ - Query context properties
+ - Filters over dimensions.
+
+Additionally, for time-series, group-by and top-n queries you can define aggregations and post-aggregations.
 
 For example, consider the following fragment of a DQL query:
 
@@ -21,7 +23,7 @@ import ing.wbaa.druid.definitions.GranularityType
 import ing.wbaa.druid.dql.DSL._
 
 val query = DQL
-  .from("wikiticker")
+  .from("wikipedia")
   .granularity(GranularityType.Hour)
   .interval("2011-06-01/2017-06-01")
   .where(d"countryName" === "Italy" or d"countryName" === "Greece")
@@ -35,7 +37,7 @@ temporal interval of the data expressed in ISO-8601, `where` defines which rows 
 computation for a query, `agg` defines functions that summarize data (e.g., count of rows) and `postAgg` defines
 specifications of processing that should happen on aggregated values.
 
-In the above example we are performing a query over the datasource `wikiticker`, using hourly granularity, for the
+In the above example we are performing a query over the datasource `wikipedia`, using hourly granularity, for the
 interval `2011-06-01` until `2017-06-01`. We are considering rows of data where the value of dimension `countryName`
 is either `Italy` or `Greece`. Furthermore, we are interested in half counting the rows. To achieve that we define
 the aggregation function `count` we name it as `agg_count` and thereafter we define a post-aggregation function named
@@ -45,7 +47,7 @@ The equivalent fragment of a Druid query expressed in JSON is given below:
 
 ```
 {
-  "dataSource" : "wikiticker",
+  "dataSource" : "wikipedia",
   "granularity" : "hour",
   "intervals" : [ "2011-06-01/2017-06-01"],
   "filter" : {
@@ -632,7 +634,7 @@ For example, the following query is a time-series that counts the number of rows
 case class TimeseriesCount(ts_count: Long)
 
 val query: TimeSeriesQuery = DQL
-    .from("wikiticker")
+    .from("wikipedia")
     .granularity(GranularityType.Hour)
     .interval("2011-06-01/2017-06-01")
     .agg(count as "ts_count")
@@ -649,7 +651,7 @@ The following query computes the Top-5 `countryName` with respect to the aggrega
 case class PostAggregationAnonymous(countryName: Option[String], agg_count: Double, half_count: Double)
 
 val query: TopNQuery = DQL
-    .from("wikiticker")
+    .from("wikipedia")
     .granularity(GranularityType.Week)
     .interval("2011-06-01/2017-06-01")
     .agg(count as "agg_count")
@@ -668,7 +670,7 @@ The following query performs group-by count over the dimension `isAnonymous`:
 case class GroupByIsAnonymous(isAnonymous: String, count: Int)
 
 val query: GroupByQuery = DQL
-    .from("wikiticker")
+    .from("wikipedia")
     .granularity(GranularityType.Day)
     .interval("2011-06-01/2017-06-01")
     .agg(count as "count")
@@ -687,7 +689,7 @@ the aggregation `count`.
 case class GroupByIsAnonymous(isAnonymous: String, country: Option[String], count: Int)
 
 val query: GroupByQuery = DQL
-    .from("wikiticker")
+    .from("wikipedia")
     .granularity(GranularityType.Day)
     .interval("2011-06-01/2017-06-01")
     .agg(count as "count")
@@ -704,7 +706,7 @@ We can avoid null values in `country` by filtering the dimension `countryName`:
 case class GroupByIsAnonymous(isAnonymous: String, country: String, count: Int)
 
 val query: GroupByQuery = DQL
-    .from("wikiticker")
+    .from("wikipedia")
     .granularity(GranularityType.Day)
     .interval("2011-06-01/2017-06-01")
     .agg(count as "count")
@@ -722,7 +724,7 @@ We can also keep only those records that they are having count above 100 and bel
 case class GroupByIsAnonymous(isAnonymous: String, country: String, count: Int)
 
 val query: GroupByQuery = DQL
-    .from("wikiticker")
+    .from("wikipedia")
     .granularity(GranularityType.Day)
     .interval("2011-06-01/2017-06-01")
     .agg(count as "count")
@@ -735,6 +737,68 @@ val query: GroupByQuery = DQL
 val response: Future[List[GroupByIsAnonymous]] = query.execute().map(_.list[GroupByIsAnonymous])
 ```
 
+#### Select query
+
+The following query performs select over the dimensions `channel`, `cityName`, `countryIsoCode` and `user`:
+
+```scala
+case class SelectResult(channel: Option[String], cityName: Option[String], countryIsoCode: Option[String], user: Option[String])
+
+val query: SelectQuery = DQL
+    .select(threshold = 10)
+    .from("wikipedia")
+    .dimensions(d"channel", d"cityName", d"countryIsoCode", d"user")
+    .granularity(GranularityType.Hour)
+    .interval("2011-06-01/2017-06-01")
+    .build()
+
+val response: Future[List[SelectResult]] = query.execute().map(_.list[SelectResult])
+```
+Select queries support pagination, in the example above the pagination threshold is set to 10 rows per block of 
+paginated results. The resulting response, however, is being flattened to a single list of results 
+(due to `_.list[SelectResult]`). The pagination can be controlled with the parameters of the official 
+[Druid documentation](https://druid.apache.org/docs/latest/querying/select-query.html#result-pagination).
+
+
+#### Scan query
+
+Similar to `SelectQuery`, the following query performs scan over the dimensions `channel`, `cityName`, `countryIsoCode` 
+and `user`:
+
+```scala
+case class ScanResult(channel: Option[String], cityName: Option[String], countryIsoCode: Option[String], user: Option[String])
+
+val query: ScanQuery = DQL
+      .scan()
+      .from("wikipedia")
+      .columns("channel", "cityName", "countryIsoCode", "user")
+      .granularity(GranularityType.Day)
+      .interval("2011-06-01/2017-06-01")
+      .build()
+```
+
+[Scan query](https://druid.apache.org/docs/latest/querying/scan-query.html) is more efficient than 
+[Select query](https://druid.apache.org/docs/latest/querying/select-query.html). The main difference is that it does 
+not support pagination, but is able to return a virtually unlimited number of results.
+
+#### Search query
+
+The following query performs case insensitive [search](https://druid.apache.org/docs/latest/querying/searchquery.html) over the dimensions `countryIsoCode`:
+
+```scala
+val query: SearchQuery = DQL
+    .search(ContainsInsensitive("GR"))
+    .from("wikipedia")
+    .granularity(GranularityType.Hour)
+    .interval("2011-06-01/2017-06-01")
+    .dimensions("countryIsoCode")
+    .build()
+
+val request: Future[List[DruidSearchResult]] = query.execute().map(_.list)
+```
+
+In contrast to rest of queries, Search query does not take type parameters as its results are of type `ing.wbaa.druid.DruidSearchResult`.
+
 ## Query Context
 
 Druid [query context](https://druid.apache.org/docs/latest/querying/query-context.html) is used for various query 
@@ -746,7 +810,7 @@ Consider, for example, a group-by query with custom `query id` and `priority`:
 
 ```scala
 val query: GroupByQuery = DQL
-    .from("wikiticker")
+    .from("wikipedia")
     .granularity(GranularityType.Day)
     .interval("2011-06-01/2017-06-01")
     .agg(count as "count")
@@ -763,7 +827,7 @@ Alternatively, context parameters can also be specified one each time by using t
 
 ```scala
 val query: GroupByQuery = DQL
-    .from("wikiticker")
+    .from("wikipedia")
     .granularity(GranularityType.Day)
     .interval("2011-06-01/2017-06-01")
     .agg(count as "count")

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -20,6 +20,10 @@ druid = {
   client-backend = "ing.wbaa.druid.client.DruidHttpClient"
   client-backend = ${?DRUID_CLIENT_BACKEND}
 
+  // When it is required, Scruid also supports legacy mode in Scan Queries. By default, legacy mode is turned off.
+  // For details see https://druid.apache.org/docs/latest/querying/scan-query.html#legacy-mode
+  scan-query-legacy-mode = false
+  scan-query-legacy-mode = ${?DRUID_SCAN_QUERY_LEGACY_MODE}
 
   client-config = {
 

--- a/src/main/scala/ing/wbaa/druid/DruidConfig.scala
+++ b/src/main/scala/ing/wbaa/druid/DruidConfig.scala
@@ -39,6 +39,7 @@ class DruidConfig(val hosts: Seq[QueryHost],
                   val responseParsingTimeout: FiniteDuration,
                   val clientBackend: Class[_ <: DruidClient],
                   val clientConfig: Config,
+                  val scanQueryLegacyMode: Boolean,
                   val system: ActorSystem) {
   def copy(
       hosts: Seq[QueryHost] = this.hosts,
@@ -48,7 +49,8 @@ class DruidConfig(val hosts: Seq[QueryHost],
       datasource: String = this.datasource,
       responseParsingTimeout: FiniteDuration = this.responseParsingTimeout,
       clientBackend: Class[_ <: DruidClient] = this.clientBackend,
-      clientConfig: Config = this.clientConfig
+      clientConfig: Config = this.clientConfig,
+      scanQueryLegacyMode: Boolean = this.scanQueryLegacyMode
   ): DruidConfig =
     new DruidConfig(hosts,
                     secure,
@@ -58,6 +60,7 @@ class DruidConfig(val hosts: Seq[QueryHost],
                     responseParsingTimeout,
                     clientBackend,
                     clientConfig,
+                    scanQueryLegacyMode,
                     system)
 
   lazy val client: DruidClient = {
@@ -99,6 +102,7 @@ object DruidConfig {
       clientBackend: Class[_ <: DruidClient] =
         Class.forName(druidConfig.getString("client-backend")).asInstanceOf[Class[DruidClient]],
       clientConfig: Config = druidConfig.getConfig("client-config"),
+      scanQueryLegacyMode: Boolean = druidConfig.getBoolean("scan-query-legacy-mode"),
       system: ActorSystem = ActorSystem("scruid-actor-system")
   ): DruidConfig =
     new DruidConfig(hosts,
@@ -109,6 +113,7 @@ object DruidConfig {
                     responseParsingTimeout,
                     clientBackend,
                     clientConfig,
+                    scanQueryLegacyMode,
                     system)
 
   /**

--- a/src/main/scala/ing/wbaa/druid/DruidQuery.scala
+++ b/src/main/scala/ing/wbaa/druid/DruidQuery.scala
@@ -28,31 +28,60 @@ import io.circe.generic.auto._
 import io.circe.syntax._
 import io.circe._
 
-import scala.concurrent.Future
+import scala.concurrent.{ ExecutionContext, Future }
 
 sealed trait QueryType extends Enum with CamelCaseEnumStringEncoder
 object QueryType extends EnumCodec[QueryType] {
   case object TopN       extends QueryType
   case object GroupBy    extends QueryType
   case object Timeseries extends QueryType
+  case object Scan       extends QueryType
+  case object Select     extends QueryType
+  case object Search     extends QueryType
   val values: Set[QueryType] = sealerate.values[QueryType]
 }
 
 sealed trait DruidQuery {
+
   val queryType: QueryType
   val dataSource: String
-  val granularity: Granularity
-  val aggregations: Iterable[Aggregation]
-  val filter: Option[Filter]
-  val intervals: Iterable[String]
   val context: Map[String, String]
+
+  /**
+    * Utility method that converts the query to the corresponding native Druid JSON request
+    *
+    * @return corresponding JSON representation of the query
+    */
+  def toDebugString: String = this.asInstanceOf[DruidQuery].asJson.toString()
+
+}
+
+object DruidQuery {
+
+  implicit val encoder: Encoder[DruidQuery] = new Encoder[DruidQuery] {
+    final def apply(query: DruidQuery): Json =
+      (query match {
+        case x: GroupByQuery    => x.asJsonObject
+        case x: TimeSeriesQuery => x.asJsonObject
+        case x: TopNQuery       => x.asJsonObject
+        case x: ScanQuery       => x.asJsonObject
+        case x: SelectQuery     => x.asJsonObject
+        case x: SearchQuery     => x.asJsonObject
+      }).add("queryType", query.queryType.asJson)
+        .add("dataSource", query.dataSource.asJson)
+        .asJson
+  }
+}
+
+sealed trait DruidQueryFunctions {
+  this: DruidQuery =>
 
   def execute()(implicit config: DruidConfig = DruidConfig.DefaultConfig): Future[DruidResponse] =
     config.client.doQuery(this)
 
   def stream()(
       implicit config: DruidConfig = DruidConfig.DefaultConfig
-  ): Source[DruidResult, NotUsed] =
+  ): Source[BaseResult, NotUsed] =
     config.client.doQueryAsStream(this)
 
   def streamAs[T]()(
@@ -61,7 +90,6 @@ sealed trait DruidQuery {
   ): Source[T, NotUsed] = {
 
     val source = this.stream()
-
     queryType match {
       case QueryType.TopN => source.mapConcat(result => result.as[List[T]])
       case _              => source.map(result => result.as[T])
@@ -83,20 +111,6 @@ sealed trait DruidQuery {
   }
 }
 
-object DruidQuery {
-
-  implicit val encoder: Encoder[DruidQuery] = new Encoder[DruidQuery] {
-    final def apply(query: DruidQuery): Json =
-      (query match {
-        case x: GroupByQuery    => x.asJsonObject
-        case x: TimeSeriesQuery => x.asJsonObject
-        case x: TopNQuery       => x.asJsonObject
-      }).add("queryType", query.queryType.asJson)
-        .add("dataSource", query.dataSource.asJson)
-        .asJson
-  }
-}
-
 case class GroupByQuery(
     aggregations: Iterable[Aggregation],
     intervals: Iterable[String],
@@ -108,7 +122,8 @@ case class GroupByQuery(
     postAggregations: Iterable[PostAggregation] = Iterable.empty,
     context: Map[QueryContextParam, QueryContextValue] = Map.empty
 )(implicit val config: DruidConfig = DruidConfig.DefaultConfig)
-    extends DruidQuery {
+    extends DruidQuery
+    with DruidQueryFunctions {
   val queryType          = QueryType.GroupBy
   val dataSource: String = config.datasource
 }
@@ -156,7 +171,8 @@ case class TimeSeriesQuery(
     postAggregations: Iterable[PostAggregation] = Iterable.empty,
     context: Map[QueryContextParam, QueryContextValue] = Map.empty
 )(implicit val config: DruidConfig = DruidConfig.DefaultConfig)
-    extends DruidQuery {
+    extends DruidQuery
+    with DruidQueryFunctions {
   val queryType          = QueryType.Timeseries
   val dataSource: String = config.datasource
 }
@@ -172,8 +188,129 @@ case class TopNQuery(
     postAggregations: Iterable[PostAggregation] = Iterable.empty,
     context: Map[QueryContextParam, QueryContextValue] = Map.empty
 )(implicit val config: DruidConfig = DruidConfig.DefaultConfig)
-    extends DruidQuery {
+    extends DruidQuery
+    with DruidQueryFunctions {
   val queryType          = QueryType.TopN
   val dataSource: String = config.datasource
 
+}
+
+case class ScanQuery private (
+    granularity: Granularity,
+    intervals: Iterable[String],
+    filter: Option[Filter],
+    columns: Iterable[String],
+    batchSize: Option[Int],
+    limit: Option[Int],
+    order: Option[Order],
+    legacy: Option[Boolean],
+    context: Map[QueryContextParam, QueryContextValue]
+)(implicit val config: DruidConfig)
+    extends DruidQuery
+    with DruidQueryFunctions {
+
+  val queryType: QueryType = QueryType.Scan
+  val dataSource: String   = config.datasource
+  val resultFormat: String = "list"
+}
+
+object ScanQuery {
+
+  def apply(
+      granularity: Granularity,
+      intervals: Iterable[String],
+      columns: Iterable[String] = Iterable.empty,
+      filter: Option[Filter] = None,
+      batchSize: Option[Int] = None,
+      limit: Option[Int] = None,
+      order: Order = OrderType.None,
+      context: Map[QueryContextParam, QueryContextValue] = Map.empty
+  )(implicit config: DruidConfig = DruidConfig.DefaultConfig): ScanQuery = {
+
+    // Depending on the mode (legacy or not) the name of the time dimension is either named as 'timestamp' or '__time'
+    val timeDimensionName = if (config.scanQueryLegacyMode) "timestamp" else "__time"
+
+    // When specific columns and metrics are defined, then we have to make sure that the time dimension is
+    // also included. In any other case, we simply passthrough the specified columns --- as the columns are either
+    // empty (meaning that all dimensions and metrics will be returned, including the time dimension) or the time
+    // dimension is already included in `columns`. Please note that we need the time dimension, since it is a
+    // mandatory field of [[ing.wbaa.druid.BaseResult]] and it is used by the implementations
+    // of [[ing.wbaa.druid.DruidResponse.series]]
+    val resultingColumns: Iterable[String] =
+      if (columns.isEmpty || columns.exists(_ == timeDimensionName)) columns
+      else timeDimensionName :: (columns.toList)
+
+    new ScanQuery(granularity,
+                  intervals,
+                  filter,
+                  resultingColumns,
+                  batchSize,
+                  limit,
+                  Option(order),
+                  Option(config.scanQueryLegacyMode),
+                  context)
+  }
+}
+
+case class SelectQuery(
+    granularity: Granularity,
+    intervals: Iterable[String],
+    pagingSpec: PagingSpec,
+    filter: Option[Filter] = None,
+    descending: Boolean = false,
+    dimensions: Iterable[Dimension] = Iterable.empty,
+    metrics: Iterable[String] = Iterable.empty,
+    context: Map[QueryContextParam, QueryContextValue] = Map.empty
+)(implicit val config: DruidConfig = DruidConfig.DefaultConfig)
+    extends DruidQuery
+    with DruidQueryFunctions {
+  val queryType          = QueryType.Select
+  val dataSource: String = config.datasource
+}
+
+case class PagingSpec(
+    threshold: Int,
+    fromNext: Boolean = true,
+    pagingIdentifiers: Map[String, Int] = Map.empty
+)
+
+object PagingSpec {
+  def legacy(threshold: Int, pagingIdentifiers: Map[String, Int] = Map.empty): PagingSpec =
+    new PagingSpec(threshold, false, pagingIdentifiers)
+}
+
+case class SearchQuery(
+    granularity: Granularity,
+    intervals: Iterable[String],
+    query: SearchQuerySpec,
+    filter: Option[Filter] = None,
+    limit: Option[Int] = None,
+    searchDimensions: Iterable[String] = Iterable.empty,
+    sort: Option[DimensionOrder] = None,
+    context: Map[QueryContextParam, QueryContextValue] = Map.empty
+)(implicit val config: DruidConfig = DruidConfig.DefaultConfig)
+    extends DruidQuery {
+
+  val queryType          = QueryType.Search
+  val dataSource: String = config.datasource
+
+  def execute()(
+      implicit config: DruidConfig = DruidConfig.DefaultConfig,
+      ec: ExecutionContext = config.client.actorSystem.dispatcher
+  ): Future[DruidResponseSearch] =
+    config.client.doQuery(this).map(DruidResponseSearch)
+
+  def stream()(implicit config: DruidConfig): Source[DruidSearchResult, NotUsed] =
+    config.client.doQueryAsStream(this).mapConcat(_.as[List[DruidSearchResult]])
+
+  def streamSeries()(
+      implicit config: DruidConfig
+  ): Source[(ZonedDateTime, DruidSearchResult), NotUsed] =
+    config.client
+      .doQueryAsStream(this)
+      .mapConcat { response =>
+        response
+          .as[List[DruidSearchResult]]
+          .map(result => response.timestamp -> result)
+      }
 }

--- a/src/main/scala/ing/wbaa/druid/DruidResponse.scala
+++ b/src/main/scala/ing/wbaa/druid/DruidResponse.scala
@@ -21,10 +21,26 @@ import java.time._
 
 import ing.wbaa.druid.client.CirceDecoders
 import io.circe._
+
 import scala.collection.immutable.ListMap
+import io.circe.Decoder.Result
+import io.circe.generic.semiauto.deriveDecoder
+
 import cats.syntax.either._ // DO NOT REMOVE: required for scala 2.11
 
-case class DruidResponse(results: List[DruidResult], queryType: QueryType) {
+sealed trait DruidResponse extends CirceDecoders {
+
+  def list[T](implicit decoder: Decoder[T]): List[T]
+
+  def series[T](implicit decoder: Decoder[T]): ListMap[ZonedDateTime, List[T]]
+}
+
+case class DruidResponseTimeseriesImpl(results: List[DruidResult], queryType: QueryType)
+    extends DruidResponse {
+
+  private implicit val decoderDruidSelectEvent  = DruidSelectEvent.decoder
+  private implicit val decoderDruidSelectResult = DruidSelectEvents.decoder
+
   private def decodeList[T](implicit decoder: Decoder[T]): List[T] = results.map { result =>
     result.as[T](decoder)
   }
@@ -35,23 +51,36 @@ case class DruidResponse(results: List[DruidResult], queryType: QueryType) {
       case Right(value) => value
     }
 
-  def list[T](implicit decoder: Decoder[T]): List[T] = queryType match {
-    case QueryType.TopN => decodeList[List[T]].flatten
-    case _              => decodeList[T]
+  override def list[T](implicit decoder: Decoder[T]): List[T] = queryType match {
+    case QueryType.TopN   => decodeList[List[T]].flatten
+    case QueryType.Select => decodeList[DruidSelectEvents].flatMap(_.events.map(_.as[T]))
+    case _                => decodeList[T]
   }
 
-  def series[T](implicit decoder: Decoder[T]): ListMap[ZonedDateTime, List[T]] =
+  override def series[T](implicit decoder: Decoder[T]): ListMap[ZonedDateTime, List[T]] =
     results.foldLeft[ListMap[ZonedDateTime, List[T]]](ListMap.empty) {
       case (acc, DruidResult(timestamp, result)) =>
+        val elements = queryType match {
+          case QueryType.Select =>
+            decode[DruidSelectEvents](result).events.map(_.as[T])
+          case _ =>
+            List(decode(result)(decoder))
+        }
+
         acc ++ ListMap(
-          timestamp -> (acc.getOrElse(timestamp, List.empty[T]) :+ decode(result)(decoder))
+          timestamp -> (acc.getOrElse(timestamp, List.empty[T]) ++ elements)
         )
     }
 }
 
-case class DruidResult(timestamp: ZonedDateTime, result: Json) {
+sealed trait BaseResult {
+  def as[T](implicit decoder: Decoder[T]): T
+  val timestamp: ZonedDateTime
+}
 
-  def as[T](implicit decoder: Decoder[T]): T = decoder.decodeJson(this.result) match {
+case class DruidResult(timestamp: ZonedDateTime, result: Json) extends BaseResult {
+
+  override def as[T](implicit decoder: Decoder[T]): T = decoder.decodeJson(this.result) match {
     case Left(e)      => throw e
     case Right(value) => value
   }
@@ -60,8 +89,8 @@ case class DruidResult(timestamp: ZonedDateTime, result: Json) {
 object DruidResult extends CirceDecoders {
   private def extractResultField(c: HCursor): ACursor = {
     val result = c.downField("result")
-    val event  = c.downField("event")
-    if (result.succeeded) result else event
+
+    if (result.succeeded) result else c.downField("event")
   }
 
   implicit val decoder: Decoder[DruidResult] = new Decoder[DruidResult] {
@@ -69,9 +98,121 @@ object DruidResult extends CirceDecoders {
       for {
         timestamp <- c.downField("timestamp").as[ZonedDateTime]
         result    <- extractResultField(c).as[Json]
-      } yield {
-
-        DruidResult(timestamp, result)
-      }
+      } yield DruidResult(timestamp, result)
   }
+}
+
+case class DruidSelectEvent(
+    segmentId: String,
+    offset: Long,
+    event: Json
+) extends BaseResult
+    with CirceDecoders {
+
+  def as[T](implicit decoder: Decoder[T]): T = decoder.decodeJson(this.event) match {
+    case Left(e)      => throw e
+    case Right(value) => value
+  }
+
+  override val timestamp: ZonedDateTime =
+    event.hcursor.downField("timestamp").as[ZonedDateTime] match {
+      case Left(error)  => throw error
+      case Right(value) => value
+    }
+}
+
+object DruidSelectEvent {
+  implicit val decoder = deriveDecoder[DruidSelectEvent]
+}
+
+case class DruidSelectEvents(
+    pagingIdentifiers: Map[String, Long],
+    dimensions: Seq[String],
+    metrics: Seq[String],
+    events: List[DruidSelectEvent]
+)
+
+object DruidSelectEvents {
+  implicit val decoder = deriveDecoder[DruidSelectEvents]
+}
+
+case class DruidResponseScanImpl(results: List[DruidScanResults]) extends DruidResponse {
+
+  override def list[T](implicit decoder: Decoder[T]): List[T] = results.flatMap(_.as[T])
+
+  override def series[T](implicit decoder: Decoder[T]): ListMap[ZonedDateTime, List[T]] =
+    results.foldLeft(ListMap.empty[ZonedDateTime, List[T]]) { (acc, scanResult) =>
+      scanResult.events
+        .map(event => event.timestamp -> event.as[T])
+        .groupBy { case (timestamp, _) => timestamp }
+        .foldLeft(acc) { (internalAcc, record) =>
+          val (timestamp, entries) = record
+          val elements             = entries.map { case (_, event) => event }
+          internalAcc ++ ListMap(
+            timestamp -> (internalAcc.getOrElse(timestamp, List.empty[T]) ++ elements)
+          )
+        }
+    }
+}
+
+case class DruidScanResults(
+    segmentId: String,
+    columns: Seq[String],
+    events: List[DruidScanResult]
+) {
+
+  def as[T](implicit decoder: Decoder[T]): List[T] = events.map(_.as[T])
+
+}
+
+object DruidScanResults {
+  implicit val decoder: Decoder[DruidScanResults] = deriveDecoder[DruidScanResults]
+}
+
+case class DruidScanResult(result: Json) extends BaseResult with CirceDecoders {
+
+  override val timestamp: ZonedDateTime = {
+    val timestampField = result.hcursor.downField("timestamp")
+
+    if (timestampField.succeeded) {
+      timestampField
+        .as[ZonedDateTime]
+        .getOrElse(throw new IllegalStateException("Failed to parse JSON field 'timestamp'"))
+    } else {
+      val milliseconds = result.hcursor
+        .downField("__time")
+        .as[Long]
+        .getOrElse(throw new IllegalStateException(s"Failed to parse JSON field '__time'"))
+
+      ZonedDateTime.ofInstant(Instant.ofEpochMilli(milliseconds), ZoneId.of("UTC"))
+    }
+  }
+
+  def as[T](implicit decoder: Decoder[T]): T =
+    result.as[T] match {
+      case Left(error)  => throw error
+      case Right(value) => value
+    }
+}
+
+object DruidScanResult {
+
+  implicit val decoder: Decoder[DruidScanResult] = new Decoder[DruidScanResult] {
+    override def apply(c: HCursor): Result[DruidScanResult] = Right(DruidScanResult(c.value))
+  }
+
+}
+
+case class DruidResponseSearch(response: DruidResponse) {
+  def list: List[DruidSearchResult] = response.list[List[DruidSearchResult]].flatten
+  def series: ListMap[ZonedDateTime, List[DruidSearchResult]] =
+    response.series[List[DruidSearchResult]].map {
+      case (zonedDateTime, entries) => zonedDateTime -> entries.flatten
+    }
+}
+
+case class DruidSearchResult(dimension: String, value: String, count: Long)
+
+object DruidSearchResult {
+  implicit val decoder: Decoder[DruidSearchResult] = deriveDecoder[DruidSearchResult]
 }

--- a/src/main/scala/ing/wbaa/druid/client/DruidAdvancedHttpClient.scala
+++ b/src/main/scala/ing/wbaa/druid/client/DruidAdvancedHttpClient.scala
@@ -28,10 +28,10 @@ import akka.http.scaladsl.settings.ConnectionPoolSettings
 import akka.stream._
 import akka.stream.scaladsl._
 import com.typesafe.config.{ Config, ConfigException, ConfigFactory, ConfigValueFactory }
-import ing.wbaa.druid.{ DruidConfig, DruidQuery, DruidResponse, DruidResult, QueryHost }
+import ing.wbaa.druid.{ BaseResult, DruidConfig, DruidQuery, DruidResponse, QueryHost }
 import akka.pattern.retry
-import scala.reflect.runtime.universe
 
+import scala.reflect.runtime.universe
 import scala.concurrent.duration._
 import scala.concurrent.{ ExecutionContext, ExecutionContextExecutor, Future, Promise }
 import scala.util.{ Failure, Success, Try }
@@ -121,7 +121,7 @@ class DruidAdvancedHttpClient private (
 
   override def doQueryAsStream(
       query: DruidQuery
-  )(implicit druidConfig: DruidConfig): Source[DruidResult, NotUsed] = {
+  )(implicit druidConfig: DruidConfig): Source[BaseResult, NotUsed] = {
     val responsePromise = Promise[HttpResponse]()
 
     Source
@@ -133,7 +133,7 @@ class DruidAdvancedHttpClient private (
 
         case (Success(response), _) =>
           responsePromise.future.flatMap(Future.successful)
-          handleResponseAsStream(response)
+          handleResponseAsStream(response, query.queryType)
 
         case (Failure(ex), _) =>
           responsePromise.future.flatMap(_ => Future.failed(ex))

--- a/src/main/scala/ing/wbaa/druid/client/DruidClient.scala
+++ b/src/main/scala/ing/wbaa/druid/client/DruidClient.scala
@@ -152,7 +152,7 @@ trait DruidResponseHandler extends CirceDecoders {
           queryType match {
             case QueryType.Scan =>
               decode[List[DruidScanResults]](json).right
-                .map(results => DruidResponseScanImpl(results))
+                .map(results => DruidScanResponse(results))
             case _ =>
               decode[List[DruidResult]](json).right
                 .map(results => DruidResponseTimeseriesImpl(results, queryType))

--- a/src/main/scala/ing/wbaa/druid/client/DruidHttpClient.scala
+++ b/src/main/scala/ing/wbaa/druid/client/DruidHttpClient.scala
@@ -67,11 +67,11 @@ class DruidHttpClient private (connectionFlow: DruidHttpClient.ConnectionFlowTyp
 
   override def doQueryAsStream(
       query: DruidQuery
-  )(implicit druidConfig: DruidConfig): Source[DruidResult, NotUsed] =
+  )(implicit druidConfig: DruidConfig): Source[BaseResult, NotUsed] =
     Source
       .fromFuture(createHttpRequest(query))
       .via(connectionFlow)
-      .flatMapConcat(handleResponseAsStream)
+      .flatMapConcat(response => handleResponseAsStream(response, query.queryType))
 
   override def shutdown(): Future[Unit] = Future.successful(())
 

--- a/src/main/scala/ing/wbaa/druid/definitions/Boundary.scala
+++ b/src/main/scala/ing/wbaa/druid/definitions/Boundary.scala
@@ -1,0 +1,18 @@
+package ing.wbaa.druid
+package definitions
+
+import io.circe._
+import ca.mrvisser.sealerate
+
+sealed trait Boundary extends Enum with CamelCaseEnumStringEncoder
+
+object Boundary {
+  implicit val boundEncoder: Encoder[Boundary] = BoundaryType.encoder
+  implicit val boundDecoder: Decoder[Boundary] = BoundaryType.decoder
+}
+
+object BoundaryType extends EnumCodec[Boundary] {
+  case object MaxTime extends Boundary
+  case object MinTime extends Boundary
+  val values: Set[Boundary] = sealerate.values[Boundary]
+}

--- a/src/main/scala/ing/wbaa/druid/definitions/Filter.scala
+++ b/src/main/scala/ing/wbaa/druid/definitions/Filter.scala
@@ -165,13 +165,13 @@ case class SearchFilter(dimension: String,
   val `type` = FilterType.Search
 }
 
-sealed trait SearchQuerySpecType extends Enum with CamelCaseEnumStringEncoder
+sealed trait SearchQuerySpecType extends Enum with SnakeCaseEnumStringEncoder
 
 object SearchQuerySpecType extends EnumCodec[SearchQuerySpecType] {
   case object Contains            extends SearchQuerySpecType
   case object InsensitiveContains extends SearchQuerySpecType
   case object Fragment            extends SearchQuerySpecType
-
+  case object Regex               extends SearchQuerySpecType
   val values: Set[SearchQuerySpecType] = sealerate.values[SearchQuerySpecType]
 }
 
@@ -186,6 +186,7 @@ object SearchQuerySpec {
         case x: ContainsCaseSensitive => x.asJsonObject
         case x: ContainsInsensitive   => x.asJsonObject
         case x: Fragment              => x.asJsonObject
+        case x: Regex                 => x.asJsonObject
       }).add("type", contains.`type`.asJson).asJson
   }
 }
@@ -202,6 +203,10 @@ case class ContainsInsensitive(value: String) extends SearchQuerySpec {
 case class Fragment(values: Iterable[String], caseSensitive: Option[Boolean] = None)
     extends SearchQuerySpec {
   val `type` = SearchQuerySpecType.Fragment
+}
+
+case class Regex(pattern: String) extends SearchQuerySpec {
+  val `type` = SearchQuerySpecType.Regex
 }
 
 case class SpatialFilter(dimension: String, bound: SpatialBound) extends Filter {

--- a/src/main/scala/ing/wbaa/druid/definitions/Order.scala
+++ b/src/main/scala/ing/wbaa/druid/definitions/Order.scala
@@ -1,0 +1,21 @@
+package ing.wbaa.druid
+package definitions
+
+import io.circe._
+import ca.mrvisser.sealerate
+
+sealed trait Order extends Enum with LowerCaseEnumStringEncoder
+
+object Order {
+  implicit val orderEncoder: Encoder[Order] = OrderType.encoder
+  implicit val orderDecoder: Decoder[Order] = OrderType.decoder
+}
+
+object OrderType extends EnumCodec[Order] {
+
+  case object Ascending extends Order
+  case object Decending extends Order
+  case object None      extends Order
+
+  val values: Set[Order] = sealerate.values[Order]
+}

--- a/src/main/scala/ing/wbaa/druid/dql/Dim.scala
+++ b/src/main/scala/ing/wbaa/druid/dql/Dim.scala
@@ -190,7 +190,7 @@ case class Dim private[dql] (name: String,
   /**
     * @return regex-filter of this dimension for the specified Java regular expression pattern
     */
-  def regex(pattern: String): FilteringExpression = new Regex(this, pattern)
+  def regex(pattern: String): FilteringExpression = new RegexExp(this, pattern)
 
   /**
     * @return selector expression stating that the contents of the dimension should be null

--- a/src/main/scala/ing/wbaa/druid/dql/expressions/Filtering.scala
+++ b/src/main/scala/ing/wbaa/druid/dql/expressions/Filtering.scala
@@ -101,7 +101,7 @@ class Like(dim: Dim, pattern: String) extends FilteringExpression with FilterOnl
   override protected[dql] def createFilter: Filter = LikeFilter(dim.name, pattern)
 }
 
-class Regex(dim: Dim, pattern: String) extends FilteringExpression with FilterOnlyOperator {
+class RegexExp(dim: Dim, pattern: String) extends FilteringExpression with FilterOnlyOperator {
   override protected[dql] def createFilter: Filter = RegexFilter(dim.name, pattern)
 }
 


### PR DESCRIPTION
  - Changes interval query and response API in order to support the three new queries
  - Legacy mode for Scan queries is configurable from application.conf
  - Updates documentation and examples for new queries
  - Updates unit tests to examine new queries
  - All Druid Queries have toDebugString utility function, in order to get the corresponding native JSON representation of the query as a string (useful for debugging purposes)

GH-83