### PR TITLE
Adds missing Float and String aggregators

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -98,7 +98,7 @@ lazy val root = (project in file("."))
   .settings(commonSettings)
   .settings(
     name := "scruid",
-    version := "2.3.0",
+    version := "2.3.1-SNAPSHOT",
     resolvers += Resolver.sonatypeRepo("releases"),
     libraryDependencies ++= Seq(
       "com.typesafe"           % "config"                   % typesafeConfigVersion,

--- a/docs/dql.md
+++ b/docs/dql.md
@@ -386,8 +386,8 @@ or Double.NEGATIVE_INFINITY, respectively.
 
 #### First / Last aggregator
 
-`longFirst`, `floatFirst` and `doubleFirst` computes the metric value with the minimum timestamp or 0 if no row exist.
-`longLast`, `floatLast` and `doubleLast` computes the metric value with the maximum timestamp or 0 if no row exist
+`longFirst`, `floatFirst` and `doubleFirst` computes the metric value with the minimum timestamp or 0 if no row exists.
+`longLast`, `floatLast` and `doubleLast` computes the metric value with the maximum timestamp or 0 if no row exists.
 
 ```scala
 // can be defined over some dimension
@@ -397,8 +397,8 @@ d"dim_name".longFirst as "agg_first"
 doubleLast(d"dim_name") as "agg_last"
 ```
 
-`stringFirst` computes the metric value with the minimum timestamp or `null` if no row exist. 
-`stringLast` computes the metric value with the maximum timestamp or `null` if no row exist.
+`stringFirst` computes the metric value with the minimum timestamp or `null` if no row exists. 
+`stringLast` computes the metric value with the maximum timestamp or `null` if no row exists.
 
 ```scala
 // can be defined over some dimension

--- a/docs/dql.md
+++ b/docs/dql.md
@@ -357,7 +357,7 @@ count as "some_count" // uses the name "some_count"
 
 #### Sum aggregators
 
-`longSum` and `doubleSum` computes the sum of values as a 64-bit signed integer or floating point value, respectively.
+`longSum`, `floatSum` and `doubleSum` computes the sum of values as a 64-bit signed integer or floating point value, respectively.
 
 ```scala
 // can be defined over some dimension
@@ -369,7 +369,7 @@ doubleSum(d"dim_name") as "agg_sum"
 
 #### Min / Max aggregators
 
-`longMin` and `doubleMin` computes the minimum of all metric values and Long.MAX_VALUE
+`longMin`, `floatMin` and `doubleMin` computes the minimum of all metric values and Long.MAX_VALUE
 or Double.POSITIVE_INFINITY, respectively.
 
 ```scala
@@ -380,14 +380,14 @@ d"dim_name".longMin as "agg_min"
 doubleMin(d"dim_name") as "agg_min"
 ```
 
-Similarly, `longMax` and `doubleMax` computes the maximum of all metric values and Long.MIN_VALUE
+Similarly, `longMax`, `floatMax` and `doubleMax` computes the maximum of all metric values and Long.MIN_VALUE
 or Double.NEGATIVE_INFINITY, respectively.
 
 
 #### First / Last aggregator
 
-`longFirst` and `doubleFirst` computes the metric value with the minimum timestamp or 0 if no row exist.
-`longLast` and `doubleLast` computes the metric value with the maximum timestamp or 0 if no row exist
+`longFirst`, `floatFirst` and `doubleFirst` computes the metric value with the minimum timestamp or 0 if no row exist.
+`longLast`, `floatLast` and `doubleLast` computes the metric value with the maximum timestamp or 0 if no row exist
 
 ```scala
 // can be defined over some dimension
@@ -397,6 +397,16 @@ d"dim_name".longFirst as "agg_first"
 doubleLast(d"dim_name") as "agg_last"
 ```
 
+`stringFirst` computes the metric value with the minimum timestamp or `null` if no row exist. 
+`stringLast` computes the metric value with the maximum timestamp or `null` if no row exist.
+
+```scala
+// can be defined over some dimension
+d"dim_name".stringFirst as "agg_first"
+
+// or as function
+stringLast(d"dim_name") as "agg_last"
+```
 #### Approximate Aggregations
 
 DQL supports `thetaSketch`, `hyperUnique` and `cardinality` approximate aggregators.

--- a/src/main/scala/ing/wbaa/druid/definitions/Aggregation.scala
+++ b/src/main/scala/ing/wbaa/druid/definitions/Aggregation.scala
@@ -30,14 +30,21 @@ object AggregationType extends EnumCodec[AggregationType] {
   case object Count       extends AggregationType
   case object LongSum     extends AggregationType
   case object DoubleSum   extends AggregationType
+  case object FloatSum    extends AggregationType
   case object DoubleMax   extends AggregationType
   case object DoubleMin   extends AggregationType
+  case object FloatMax    extends AggregationType
+  case object FloatMin    extends AggregationType
   case object LongMin     extends AggregationType
   case object LongMax     extends AggregationType
   case object DoubleFirst extends AggregationType
   case object DoubleLast  extends AggregationType
+  case object FloatFirst  extends AggregationType
+  case object FloatLast   extends AggregationType
   case object LongFirst   extends AggregationType
   case object LongLast    extends AggregationType
+  case object StringFirst extends AggregationType
+  case object StringLast  extends AggregationType
   case object ThetaSketch extends AggregationType
   case object HyperUnique extends AggregationType
   case object Cardinality extends AggregationType
@@ -75,12 +82,19 @@ object SingleFieldAggregation {
       case x: DoubleSumAggregation   => x.asJson
       case x: DoubleMaxAggregation   => x.asJson
       case x: DoubleMinAggregation   => x.asJson
+      case x: FloatSumAggregation    => x.asJson
+      case x: FloatMaxAggregation    => x.asJson
+      case x: FloatMinAggregation    => x.asJson
       case x: LongMaxAggregation     => x.asJson
       case x: LongMinAggregation     => x.asJson
       case x: DoubleFirstAggregation => x.asJson
       case x: DoubleLastAggregation  => x.asJson
+      case x: FloatFirstAggregation  => x.asJson
+      case x: FloatLastAggregation   => x.asJson
       case x: LongLastAggregation    => x.asJson
       case x: LongFirstAggregation   => x.asJson
+      case x: StringFirstAggregation => x.asJson
+      case x: StringLastAggregation  => x.asJson
       case x: ThetaSketchAggregation => x.asJson
       case x: HyperUniqueAggregation => x.asJson
     }
@@ -100,6 +114,15 @@ case class DoubleMaxAggregation(name: String, fieldName: String) extends SingleF
 case class DoubleMinAggregation(name: String, fieldName: String) extends SingleFieldAggregation {
   val `type` = AggregationType.DoubleMin
 }
+case class FloatSumAggregation(name: String, fieldName: String) extends SingleFieldAggregation {
+  val `type` = AggregationType.FloatSum
+}
+case class FloatMaxAggregation(name: String, fieldName: String) extends SingleFieldAggregation {
+  val `type` = AggregationType.FloatMax
+}
+case class FloatMinAggregation(name: String, fieldName: String) extends SingleFieldAggregation {
+  val `type` = AggregationType.FloatMin
+}
 case class LongMinAggregation(name: String, fieldName: String) extends SingleFieldAggregation {
   val `type` = AggregationType.LongMin
 }
@@ -112,12 +135,37 @@ case class DoubleFirstAggregation(name: String, fieldName: String) extends Singl
 case class DoubleLastAggregation(name: String, fieldName: String) extends SingleFieldAggregation {
   val `type` = AggregationType.DoubleLast
 }
+case class FloatFirstAggregation(name: String, fieldName: String) extends SingleFieldAggregation {
+  val `type` = AggregationType.FloatFirst
+}
+case class FloatLastAggregation(name: String, fieldName: String) extends SingleFieldAggregation {
+  val `type` = AggregationType.FloatLast
+}
 case class LongFirstAggregation(name: String, fieldName: String) extends SingleFieldAggregation {
   val `type` = AggregationType.LongFirst
 }
 case class LongLastAggregation(name: String, fieldName: String) extends SingleFieldAggregation {
   val `type` = AggregationType.LongLast
 }
+
+case class StringFirstAggregation(
+    name: String,
+    fieldName: String,
+    maxStringBytes: Option[Int] = None,
+    filterNullValues: Boolean = false
+) extends SingleFieldAggregation {
+  val `type` = AggregationType.StringFirst
+}
+
+case class StringLastAggregation(
+    name: String,
+    fieldName: String,
+    maxStringBytes: Option[Int] = None,
+    filterNullValues: Boolean = false
+) extends SingleFieldAggregation {
+  val `type` = AggregationType.StringLast
+}
+
 case class ThetaSketchAggregation(name: String,
                                   fieldName: String,
                                   isInputThetaSketch: Boolean = false,

--- a/src/main/scala/ing/wbaa/druid/dql/Dim.scala
+++ b/src/main/scala/ing/wbaa/druid/dql/Dim.scala
@@ -521,6 +521,41 @@ case class Dim private[dql] (name: String,
   def doubleLast: AggregationExpression = AggregationOps.doubleLast(this)
 
   /**
+    * Aggregation to compute the sum of values (as a 32-bit floating point value)
+    */
+  def floatSum: AggregationExpression = AggregationOps.floatSum(this)
+
+  /**
+    * Aggregation to compute the maximum of all metric values and Float.NEGATIVE_INFINITY
+    */
+  def floatMax: AggregationExpression = AggregationOps.floatMax(this)
+
+  /**
+    * Aggregation to compute the minimum of all metric values and Float.POSITIVE_INFINITY
+    */
+  def floatMin: AggregationExpression = AggregationOps.floatMin(this)
+
+  /**
+    * Aggregation to compute the metric value with the minimum timestamp or 0 if no row exist
+    */
+  def floatFirst: AggregationExpression = AggregationOps.floatFirst(this)
+
+  /**
+    * Aggregation to compute the metric value with the maximum timestamp or 0 if no row exist
+    */
+  def floatLast: AggregationExpression = AggregationOps.floatLast(this)
+
+  /**
+    * Aggregation to compute the metric value with the minimum timestamp or null if no row exist
+    */
+  def stringFirst: AggregationExpression = AggregationOps.stringFirst(this)
+
+  /**
+    * Aggregation to compute the metric value with the maximum timestamp or null if no row exist
+    */
+  def stringLast: AggregationExpression = AggregationOps.stringLast(this)
+
+  /**
     * Aggregation to compute theta-sketches
     */
   def thetaSketch: ThetaSketchAgg = AggregationOps.thetaSketch(this)

--- a/src/main/scala/ing/wbaa/druid/dql/Operators.scala
+++ b/src/main/scala/ing/wbaa/druid/dql/Operators.scala
@@ -54,6 +54,27 @@ trait AggregationOps {
   def doubleLast(dimName: String): DoubleLastAgg = new DoubleLastAgg(dimName)
   def doubleLast(dim: Dim): DoubleLastAgg        = doubleLast(dim.name)
 
+  def floatSum(dimName: String): FloatSumAgg = new FloatSumAgg(dimName)
+  def floatSum(dim: Dim): FloatSumAgg        = floatSum(dim.name)
+
+  def floatMax(dimName: String): FloatMaxAgg = new FloatMaxAgg(dimName)
+  def floatMax(dim: Dim): FloatMaxAgg        = floatMax(dim.name)
+
+  def floatMin(dimName: String): FloatMinAgg = new FloatMinAgg(dimName)
+  def floatMin(dim: Dim): FloatMinAgg        = floatMin(dim.name)
+
+  def floatFirst(dimName: String): FloatFirstAgg = new FloatFirstAgg(dimName)
+  def floatFirst(dim: Dim): FloatFirstAgg        = floatFirst(dim.name)
+
+  def floatLast(dimName: String): FloatLastAgg = new FloatLastAgg(dimName)
+  def floatLast(dim: Dim): FloatLastAgg        = floatLast(dim.name)
+
+  def stringFirst(dimName: String): StringFirstAgg = StringFirstAgg(dimName)
+  def stringFirst(dim: Dim): StringFirstAgg        = stringFirst(dim.name)
+
+  def stringLast(dimName: String): StringLastAgg = StringLastAgg(dimName)
+  def stringLast(dim: Dim): StringLastAgg        = stringLast(dim.name)
+
   def thetaSketch(dimName: String): ThetaSketchAgg = ThetaSketchAgg(dimName)
   def thetaSketch(dim: Dim): ThetaSketchAgg        = thetaSketch(dim.name)
 
@@ -108,12 +129,23 @@ trait AggregationOps {
 
   def count: CountAgg = new CountAgg()
 
+  def javascript(fields: Iterable[Dim], fnAggregate: String, fnCombine: String, fnReset: String)(
+      implicit classTag: ClassTag[Dim]
+  ): JavascriptAgg =
+    JavascriptAgg(fields.map(_.name).toSeq, fnAggregate, fnCombine, fnReset)
+
   def javascript(name: String,
                  fields: Iterable[Dim],
                  fnAggregate: String,
                  fnCombine: String,
                  fnReset: String)(implicit classTag: ClassTag[Dim]): JavascriptAgg =
     JavascriptAgg(fields.map(_.name).toSeq, fnAggregate, fnCombine, fnReset, Option(name))
+
+  def javascript(fields: Iterable[String],
+                 fnAggregate: String,
+                 fnCombine: String,
+                 fnReset: String): JavascriptAgg =
+    JavascriptAgg(fields.toSeq, fnAggregate, fnCombine, fnReset)
 
   def javascript(name: String,
                  fields: Iterable[String],
@@ -152,6 +184,9 @@ trait PostAggregationOps {
 
   def hyperUniqueCardinality(dim: Dim): PostAggregationExpression =
     HyperUniqueCardinalityPostAgg(dim.name, dim.outputNameOpt)
+
+  def javascript(fields: Iterable[String], function: String): PostAggregationExpression =
+    JavascriptPostAgg(fields.toSeq, function)
 
   def javascript(name: String,
                  fields: Iterable[String],

--- a/src/main/scala/ing/wbaa/druid/dql/expressions/Aggregation.scala
+++ b/src/main/scala/ing/wbaa/druid/dql/expressions/Aggregation.scala
@@ -226,7 +226,7 @@ final case class StringFirstAgg(
   override def getName: String = name.getOrElse(s"string_first_${fieldName}")
 
   def maxStringBytes(v: Int): StringFirstAgg = {
-    require(v > 0)
+    require(v > 0, s"The specified value ($v) for maxStringBytes should be greater that zero")
     this.copy(maxStringBytes = Option(v))
   }
 

--- a/src/main/scala/ing/wbaa/druid/dql/expressions/Aggregation.scala
+++ b/src/main/scala/ing/wbaa/druid/dql/expressions/Aggregation.scala
@@ -151,6 +151,118 @@ final class DoubleLastAgg(fieldName: String, name: Option[String] = None)
   override def getName: String = name.getOrElse(s"double_last_$fieldName")
 }
 
+final class FloatSumAgg(fieldName: String, name: Option[String] = None)
+    extends AggregationExpression {
+
+  override protected[dql] def build(): Aggregation =
+    FloatSumAggregation(this.getName, fieldName)
+
+  override def alias(name: String): AggregationExpression =
+    new FloatSumAgg(fieldName, Option(name))
+
+  override def getName: String = name.getOrElse(s"float_sum_$fieldName")
+}
+
+final class FloatMaxAgg(fieldName: String, name: Option[String] = None)
+    extends AggregationExpression {
+
+  override protected[dql] def build(): Aggregation =
+    FloatMaxAggregation(this.getName, fieldName)
+
+  override def alias(name: String): AggregationExpression =
+    new FloatMaxAgg(fieldName, Option(name))
+
+  override def getName: String = name.getOrElse(s"float_max_$fieldName")
+}
+
+final class FloatMinAgg(fieldName: String, name: Option[String] = None)
+    extends AggregationExpression {
+
+  override protected[dql] def build(): Aggregation =
+    FloatMinAggregation(this.getName, fieldName)
+
+  override def alias(name: String): AggregationExpression =
+    new FloatMinAgg(fieldName, Option(name))
+
+  override def getName: String = name.getOrElse(s"float_min_$fieldName")
+}
+
+final class FloatFirstAgg(fieldName: String, name: Option[String] = None)
+    extends AggregationExpression {
+
+  override protected[dql] def build(): Aggregation =
+    FloatFirstAggregation(this.getName, fieldName)
+
+  override def alias(name: String): AggregationExpression =
+    new FloatFirstAgg(fieldName, Option(name))
+
+  override def getName: String = name.getOrElse(s"float_first_$fieldName")
+}
+
+final class FloatLastAgg(fieldName: String, name: Option[String] = None)
+    extends AggregationExpression {
+
+  override protected[dql] def build(): Aggregation =
+    FloatLastAggregation(this.getName, fieldName)
+
+  override def alias(name: String): AggregationExpression =
+    new FloatLastAgg(fieldName, Option(name))
+
+  override def getName: String = name.getOrElse(s"float_last_$fieldName")
+}
+
+final case class StringFirstAgg(
+    fieldName: String,
+    name: Option[String] = None,
+    maxStringBytes: Option[Int] = None,
+    filterNullValues: Boolean = false
+) extends AggregationExpression {
+
+  override protected[dql] def build(): Aggregation =
+    StringFirstAggregation(this.getName, fieldName, maxStringBytes, filterNullValues)
+
+  override def alias(name: String): AggregationExpression = this.copy(name = Option(name))
+
+  override def getName: String = name.getOrElse(s"string_first_${fieldName}")
+
+  def maxStringBytes(v: Int): StringFirstAgg = {
+    require(v > 0)
+    this.copy(maxStringBytes = Option(v))
+  }
+
+  def filterNullValues(v: Boolean): StringFirstAgg =
+    this.copy(filterNullValues = v)
+
+  def set(maxStringBytes: Int = 0, filterNullValues: Boolean = false): StringFirstAgg =
+    this.copy(maxStringBytes = if (maxStringBytes > 0) Some(maxStringBytes) else None,
+              filterNullValues = filterNullValues)
+}
+
+final case class StringLastAgg(
+    fieldName: String,
+    name: Option[String] = None,
+    maxStringBytes: Option[Int] = None,
+    filterNullValues: Boolean = false
+) extends AggregationExpression {
+
+  override protected[dql] def build(): Aggregation =
+    StringLastAggregation(this.getName, fieldName, maxStringBytes, filterNullValues)
+
+  override def alias(name: String): AggregationExpression = this.copy(name = Option(name))
+
+  override def getName: String = name.getOrElse(s"string_last_${fieldName}")
+
+  def maxStringBytes(v: Int): StringLastAgg =
+    this.copy(maxStringBytes = if (v > 1) Some(v) else None)
+
+  def filterNullValues(v: Boolean): StringLastAgg =
+    this.copy(filterNullValues = v)
+
+  def set(maxStringBytes: Int = 0, filterNullValues: Boolean = false): StringLastAgg =
+    this.copy(maxStringBytes = if (maxStringBytes > 0) Some(maxStringBytes) else None,
+              filterNullValues = filterNullValues)
+}
+
 final case class ThetaSketchAgg(fieldName: String,
                                 name: Option[String] = None,
                                 isInputThetaSketch: Boolean = false,


### PR DESCRIPTION
  - Float-based: FloatSum, FloatMin, FloatMax, FloatFirst and FloatLast
  - String-based: StringFirst and StringLast
  - Updates the corresponding DQL operators
  - Adds two missing DQL operator functions for Javascript aggregator (same arguments, but without requiring to specify an aggregator name).