### PR TITLE
Adds GitHub actions badge

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: Build project
+name: build
 
 on: [push, pull_request]
 
@@ -47,6 +47,7 @@ jobs:
       - name: Shutdown dockerized services
         run: ./services.sh down
       - name: Push docker images
+        if: github.event_name != 'pull_request'
         run: (cd docker; make push)
     env:
       _JAVA_OPTIONS: "-Xms512m -Xmx4g"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![CircleCI](https://circleci.com/gh/ing-bank/scruid.svg?style=svg)](https://circleci.com/gh/ing-bank/scruid)
+[![Build](https://github.com/ing-bank/scruid/workflows/build/badge.svg?branch=master)](https://github.com/ing-bank/scruid/actions)
 [![Codacy Badge](https://api.codacy.com/project/badge/Coverage/9b7c4adf8ad447efa9c7ea8a9ffda6b2)](https://www.codacy.com/app/fokko/scruid?utm_source=github.com&utm_medium=referral&utm_content=ing-bank/scruid&utm_campaign=Badge_Coverage)
 [![Download](https://api.bintray.com/packages/ing-bank/maven-releases/scruid/images/download.svg)](https://bintray.com/ing-bank/maven-releases/scruid/_latestVersion)
 


### PR DESCRIPTION
Adds GitHub actions badge to `README.md`:

  - replaces Circle CI badge from `README.md` with similar one from GitHub actions
  - renames CI flow from 'Build project' to 'build', in order to simply show the label 'build' in the GitHub actions the badge
  - disables docker push when 'github.event_name' is 'pull_request'

<img width="357" alt="Screenshot 2020-01-19 at 14 37 25" src="https://user-images.githubusercontent.com/7415349/72681383-a9d06380-3acb-11ea-8097-dcb69012ad28.png">
