### PR TITLE
Use requestInterceptor in health checks

### DIFF
--- a/src/main/scala/ing/wbaa/druid/client/DruidAdvancedHttpClient.scala
+++ b/src/main/scala/ing/wbaa/druid/client/DruidAdvancedHttpClient.scala
@@ -81,12 +81,9 @@ class DruidAdvancedHttpClient private (
     val checksF: Future[Iterable[(QueryHost, Boolean)]] = Future.sequence {
       brokerConnections.map {
         case (queryHost, flow) =>
-          healthLogger.debug(
-            s"healthcheck of ${queryHost.host}:${queryHost.port} started: $request"
-          )
           executeRequest(flow)(request)
             .map { response =>
-              healthLogger.debug(
+              healthLogger.info(
                 s"healthcheck of ${queryHost.host}:${queryHost.port} success: ${response.status}"
               )
               response.discardEntityBytes()
@@ -94,7 +91,7 @@ class DruidAdvancedHttpClient private (
             }
             .recover {
               case ex =>
-                healthLogger.info(
+                healthLogger.warn(
                   s"healthcheck of ${queryHost.host} on port ${queryHost.port} failed: $ex"
                 )
                 queryHost -> false

--- a/src/main/scala/ing/wbaa/druid/client/DruidAdvancedHttpClient.scala
+++ b/src/main/scala/ing/wbaa/druid/client/DruidAdvancedHttpClient.scala
@@ -30,6 +30,7 @@ import akka.stream.scaladsl._
 import com.typesafe.config.{ Config, ConfigException, ConfigFactory, ConfigValueFactory }
 import ing.wbaa.druid.{ BaseResult, DruidConfig, DruidQuery, DruidResponse, QueryHost }
 import akka.pattern.retry
+import ing.wbaa.druid.client.DruidAdvancedHttpClient.ConnectionFlow
 
 import scala.reflect.runtime.universe
 import scala.concurrent.duration._
@@ -77,27 +78,26 @@ class DruidAdvancedHttpClient private (
 
     val request = HttpRequest(HttpMethods.GET, uri = druidConfig.healthEndpoint)
 
-    val checksF = Future.sequence {
+    val checksF: Future[Iterable[(QueryHost, Boolean)]] = Future.sequence {
       brokerConnections.map {
         case (queryHost, flow) =>
-          val responsePromise = Promise[HttpResponse]()
-
-          Source
-            .single(request -> responsePromise)
-            .via(flow)
-            .runWith(Sink.head)
-            .flatMap {
-              case (Success(response), _) =>
-                Future {
-                  response.discardEntityBytes()
-                  queryHost -> (response.status == StatusCodes.OK)
-                }
-              case (Failure(ex), _) => Future.failed(ex)
+          logger.debug(s"healthcheck of ${queryHost.host}:${queryHost.port} started: $request")
+          executeRequest(flow)(request)
+            .transform {
+              case Success(response) =>
+                logger.debug(
+                  s"healthcheck of ${queryHost.host}:${queryHost.port} success: ${response.status}"
+                )
+                response.discardEntityBytes()
+                Success(queryHost -> (response.status == StatusCodes.OK))
+              case Failure(ex) =>
+                logger.info(
+                  s"healthcheck of ${queryHost.host} on port ${queryHost.port} failed: $ex"
+                )
+                Success(queryHost -> false)
             }
-            .recover { case _ => queryHost -> false }
       }
     }
-
     checksF.map(_.toMap)
   }
 
@@ -181,6 +181,30 @@ class DruidAdvancedHttpClient private (
           )
       }
   }
+
+  /**
+    * Executes the specified HttpRequest on a specific Druid connection, bypassing the load balancer
+    *
+    * @param flow the connection flow for the specific Druid host.
+    * @param request the Http request for Druid
+    *
+    * @return a future with the corresponding Http response from Druid.
+    */
+  private def executeRequest(flow: ConnectionFlow)(request: HttpRequest): Future[HttpResponse] =
+    Source
+      .single(requestInterceptor.interceptRequest(request) -> Promise[HttpResponse]())
+      .via(flow)
+      .runWith(Sink.head)
+      .flatMap {
+        case (Success(response), responsePromise) =>
+          responsePromise.success(response)
+          requestInterceptor.interceptResponse(
+            request,
+            responsePromise.future,
+            executeRequest(flow)
+          )
+        case (Failure(e), responsePromise) => responsePromise.failure(e).future
+      }
 
   private def createHttpRequest(
       query: DruidQuery

--- a/src/main/scala/ing/wbaa/druid/client/DruidAdvancedHttpClient.scala
+++ b/src/main/scala/ing/wbaa/druid/client/DruidAdvancedHttpClient.scala
@@ -81,17 +81,19 @@ class DruidAdvancedHttpClient private (
     val checksF: Future[Iterable[(QueryHost, Boolean)]] = Future.sequence {
       brokerConnections.map {
         case (queryHost, flow) =>
-          logger.debug(s"healthcheck of ${queryHost.host}:${queryHost.port} started: $request")
+          healthLogger.debug(
+            s"healthcheck of ${queryHost.host}:${queryHost.port} started: $request"
+          )
           executeRequest(flow)(request)
             .transform {
               case Success(response) =>
-                logger.debug(
+                healthLogger.debug(
                   s"healthcheck of ${queryHost.host}:${queryHost.port} success: ${response.status}"
                 )
                 response.discardEntityBytes()
                 Success(queryHost -> (response.status == StatusCodes.OK))
               case Failure(ex) =>
-                logger.info(
+                healthLogger.info(
                   s"healthcheck of ${queryHost.host} on port ${queryHost.port} failed: $ex"
                 )
                 Success(queryHost -> false)

--- a/src/main/scala/ing/wbaa/druid/client/DruidClient.scala
+++ b/src/main/scala/ing/wbaa/druid/client/DruidClient.scala
@@ -36,6 +36,8 @@ import scala.util.{ Failure, Success, Try }
 trait DruidClient extends CirceHttpSupport with CirceDecoders {
 
   protected val logger: Logger = LoggerFactory.getLogger(getClass)
+  // Execute health checks on a separate logger category so they can be filtered easily
+  protected val healthLogger: Logger = LoggerFactory.getLogger(s"${getClass.getName}.HealthCheck")
 
   logger.info(s"Using '${this.getClass.getName}' as http client")
 

--- a/src/test/scala/ing/wbaa/druid/DruidAdvancedHttpClientSpec.scala
+++ b/src/test/scala/ing/wbaa/druid/DruidAdvancedHttpClientSpec.scala
@@ -31,7 +31,12 @@ import scala.concurrent.{ ExecutionContextExecutor, Future }
 import scala.language.postfixOps
 import scala.util.Random
 
-class DruidAdvancedHttpClientSpec extends WordSpec with Matchers with ScalaFutures with Inspectors {
+class DruidAdvancedHttpClientSpec
+    extends WordSpec
+    with Matchers
+    with ScalaFutures
+    with Inspectors
+    with DiagrammedAssertions {
 
   override implicit def patienceConfig: PatienceConfig = PatienceConfig(5 minutes, 100 millis)
 
@@ -115,21 +120,16 @@ class DruidAdvancedHttpClientSpec extends WordSpec with Matchers with ScalaFutur
 
       val client = config.client
 
+      whenReady(client.healthCheck) { outcome =>
+        outcome shouldEqual expectedHealthCheck
+      }
+
       // since localhost:8086 is always failing the health status should be false
       whenReady(client.isHealthy()) { result =>
         result shouldBe false
       }
 
-      whenReady(client.healthCheck) { outcome =>
-        forAll(expectedHealthCheck) {
-          case (broker, expectedResult) =>
-            outcome(broker) shouldBe expectedResult
-        }
-
-      }
-
       config.client.shutdown().futureValue
-
     }
 
     "throw HttpStatusException for non-200 status codes" in {


### PR DESCRIPTION
Resolves #93 

- Runs health check using requestInterceptor
- Separate logger for health checks, making it easier to suppress them if desired
- Swaps assertions in the test so that the more helpful of the two messages is printed if it fails