### PR TITLE
use com.typesafe.scala-logging instead of using slf4j directly

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,6 +21,7 @@ val mdedetrichVersion       = "0.4.0"
 val scalacticVersion        = "3.0.8"
 val scalatestVersion        = "3.0.8"
 val typesafeConfigVersion   = "1.3.3"
+val typesafeLoggingVersion  = "3.9.2"
 val akkaHttpVersion         = "10.1.9"
 val sealerateVersion        = "0.0.6"
 val logbackVersion          = "1.2.3"
@@ -102,17 +103,18 @@ lazy val root = (project in file("."))
     version := "2.3.1-SNAPSHOT",
     resolvers += Resolver.sonatypeRepo("releases"),
     libraryDependencies ++= Seq(
-      "com.typesafe"           % "config"                   % typesafeConfigVersion,
-      "org.mdedetrich"         %% "akka-stream-json"        % mdedetrichVersion,
-      "org.mdedetrich"         %% "akka-http-json"          % mdedetrichVersion,
-      "org.mdedetrich"         %% "akka-stream-circe"       % mdedetrichVersion,
-      "org.mdedetrich"         %% "akka-http-circe"         % mdedetrichVersion,
-      "com.typesafe.akka"      %% "akka-http"               % akkaHttpVersion,
-      "ca.mrvisser"            %% "sealerate"               % sealerateVersion,
-      "org.scala-lang.modules" %% "scala-collection-compat" % collectionCompatVersion,
-      "ch.qos.logback"         % "logback-classic"          % logbackVersion % Provided,
-      "org.scalactic"          %% "scalactic"               % scalacticVersion,
-      "org.scalatest"          %% "scalatest"               % scalatestVersion % Test
+      "com.typesafe"               % "config"                   % typesafeConfigVersion,
+      "com.typesafe.scala-logging" %% "scala-logging"           % typesafeLoggingVersion,
+      "org.mdedetrich"             %% "akka-stream-json"        % mdedetrichVersion,
+      "org.mdedetrich"             %% "akka-http-json"          % mdedetrichVersion,
+      "org.mdedetrich"             %% "akka-stream-circe"       % mdedetrichVersion,
+      "org.mdedetrich"             %% "akka-http-circe"         % mdedetrichVersion,
+      "com.typesafe.akka"          %% "akka-http"               % akkaHttpVersion,
+      "ca.mrvisser"                %% "sealerate"               % sealerateVersion,
+      "org.scala-lang.modules"     %% "scala-collection-compat" % collectionCompatVersion,
+      "ch.qos.logback"             % "logback-classic"          % logbackVersion % Provided,
+      "org.scalactic"              %% "scalactic"               % scalacticVersion,
+      "org.scalatest"              %% "scalatest"               % scalatestVersion % Test
     )
   )
   .settings(libraryDependencies ++= scalaVersionSpecificDependencies(scalaVersion.value))

--- a/src/main/scala/ing/wbaa/druid/auth/basic/BasicAuthenticationExtension.scala
+++ b/src/main/scala/ing/wbaa/druid/auth/basic/BasicAuthenticationExtension.scala
@@ -19,12 +19,12 @@ package ing.wbaa.druid.auth.basic
 import akka.http.scaladsl.model.headers.{ Authorization, BasicHttpCredentials }
 import akka.http.scaladsl.model.HttpRequest
 import com.typesafe.config.{ Config, ConfigFactory, ConfigValueFactory }
+import com.typesafe.scalalogging.LazyLogging
 import ing.wbaa.druid.client.{
   NoopRequestInterceptor,
   RequestInterceptor,
   RequestInterceptorBuilder
 }
-import org.slf4j.LoggerFactory
 
 /**
   * Adds a basic authentication header with static credentials to every outgoing request. Does not
@@ -45,8 +45,7 @@ class BasicAuthenticationExtension(username: String, password: String)
       .withValue("password", ConfigValueFactory.fromAnyRef(password))
 }
 
-object BasicAuthenticationExtension extends RequestInterceptorBuilder {
-  private val logger = LoggerFactory.getLogger(classOf[BasicAuthenticationExtension])
+object BasicAuthenticationExtension extends RequestInterceptorBuilder with LazyLogging {
 
   override def apply(config: Config): RequestInterceptor = {
 

--- a/src/main/scala/ing/wbaa/druid/client/DruidClient.scala
+++ b/src/main/scala/ing/wbaa/druid/client/DruidClient.scala
@@ -22,9 +22,9 @@ import akka.actor.ActorSystem
 import akka.http.scaladsl.model.{ HttpEntity, HttpResponse, StatusCodes }
 import akka.stream.ActorMaterializer
 import akka.stream.scaladsl._
+import com.typesafe.scalalogging.{ LazyLogging, Logger }
 import ing.wbaa.druid._
 import org.mdedetrich.akka.http.support.CirceHttpSupport
-import org.slf4j.{ Logger, LoggerFactory }
 import io.circe.parser.decode
 import org.mdedetrich.akka.stream.support.CirceStreamSupport
 import org.typelevel.jawn.AsyncParser
@@ -33,9 +33,10 @@ import scala.concurrent.{ ExecutionContextExecutor, Future }
 import scala.concurrent.duration.FiniteDuration
 import scala.util.{ Failure, Success, Try }
 
-trait DruidClient extends CirceHttpSupport with CirceDecoders {
+trait DruidClient extends CirceHttpSupport with CirceDecoders with LazyLogging {
 
-  protected val logger: Logger = LoggerFactory.getLogger(getClass)
+  // Execute health checks on a separate logger category so they can be filtered easily
+  protected val healthLogger: Logger = Logger(s"${getClass.getName}.HealthCheck")
 
   logger.info(s"Using '${this.getClass.getName}' as http client")
 


### PR DESCRIPTION
This gives us implicit "isLevelEnabled" checks around everything and a convenient helper trait.

Prefer merging #91 and #94 before this one. Any merge conflicts that may arise will be easier to solve on this end.