### PR TITLE
Pre 2.4.0 housekeeping

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,9 +34,9 @@ jobs:
       - name: Build for Scala 2.11
         run: sbt ++2.11.12 compile
       - name: Build for Scala 2.12
-        run: sbt ++2.12.10 compile
+        run: sbt ++2.12.11 compile
       - name: Build for Scala 2.13
-        run: sbt ++2.13.1 compile
+        run: sbt ++2.13.2 compile
       - name: Code coverage report (Scala 2.12)
         run: sbt coverage test coverageReport
       - name: Archive code coverage report (Scala 2.12)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,11 +32,11 @@ jobs:
       - name: Wait Druid to become available
         run: wget localhost:8082/status
       - name: Build for Scala 2.11
-        run: sbt ++2.11.12 compile
+        run: sbt ++2.11.12 compile test:compile
       - name: Build for Scala 2.12
-        run: sbt ++2.12.11 compile
+        run: sbt ++2.12.11 compile test:compile
       - name: Build for Scala 2.13
-        run: sbt ++2.13.2 compile
+        run: sbt ++2.13.2 compile test:compile
       - name: Code coverage report (Scala 2.12)
         run: sbt coverage test coverageReport
       - name: Archive code coverage report (Scala 2.12)

--- a/README.md
+++ b/README.md
@@ -8,6 +8,18 @@ Scruid (Scala+Druid) is an open source library that allows you to compose Druid 
 
 Currently, the API is under heavy development, so changes might occur.
 
+## Release Notes
+
+Please view the [Releases](https://github.com/ing-bank/scruid/releases) page on GitHub.
+
+## Installation
+
+The binaries are hosted on Bintray. We publish builds for Scala 2.11, 2.12 and 2.13.
+
+```sbt
+libraryDependencies += "ing.wbaa.druid" %% "scruid" % "2.4.0"
+```
+
 ## Example queries:
 
 Scruid provides query constructors for `TopNQuery`, `GroupByQuery`, `TimeSeriesQuery`, `ScanQuery` and `SearchQuery` (see below for details). You can call the `execute` method on a query to send the query to Druid. This will return a `Future[DruidResponse]`. This response contains the [Circe](http://circe.io) JSON data without having it parsed to a specific case class yet. To interpret this JSON data you can run two methods on a `DruidResponse`:

--- a/build.sbt
+++ b/build.sbt
@@ -17,15 +17,15 @@
 
 val circeForScala211Version = "0.11.1" // Only for Scala v2.11
 val circeLatestVersion      = "0.12.1" // for Scala v2.12+
-val mdedetrichVersion       = "0.4.0"
+val mdedetrichVersion       = "0.5.0"
 val scalacticVersion        = "3.0.8"
 val scalatestVersion        = "3.0.8"
-val typesafeConfigVersion   = "1.3.3"
+val typesafeConfigVersion   = "1.4.0"
 val typesafeLoggingVersion  = "3.9.2"
-val akkaHttpVersion         = "10.1.9"
+val akkaHttpVersion         = "10.1.11"
 val sealerateVersion        = "0.0.6"
 val logbackVersion          = "1.2.3"
-val collectionCompatVersion = "2.1.2"
+val collectionCompatVersion = "2.1.6"
 
 def scalaVersionSpecificDependencies(scalaVer: String): Seq[ModuleID] = {
 
@@ -86,7 +86,7 @@ lazy val commonSettings: Seq[Setting[_]] = Seq(
       s"git@github.com:${bintrayOrganization.value.get}/${name.value}.git"
     )
   ),
-  crossScalaVersions in ThisBuild := Seq("2.11.12", "2.12.10", "2.13.1"),
+  crossScalaVersions in ThisBuild := Seq("2.11.12", "2.12.11", "2.13.2"),
   scalaVersion in ThisBuild := "2.12.9",
   scalacOptions ++= Seq(Opts.compile.deprecation, "-Xlint", "-feature"),
   scalacOptions ++= unusedWarnings(scalaVersion.value),
@@ -113,7 +113,7 @@ lazy val root = (project in file("."))
       "ca.mrvisser"                %% "sealerate"               % sealerateVersion,
       "org.scala-lang.modules"     %% "scala-collection-compat" % collectionCompatVersion,
       "ch.qos.logback"             % "logback-classic"          % logbackVersion % Provided,
-      "org.scalactic"              %% "scalactic"               % scalacticVersion,
+      "org.scalactic"              %% "scalactic"               % scalacticVersion % Test,
       "org.scalatest"              %% "scalatest"               % scalatestVersion % Test
     )
   )

--- a/build.sbt
+++ b/build.sbt
@@ -87,7 +87,7 @@ lazy val commonSettings: Seq[Setting[_]] = Seq(
     )
   ),
   crossScalaVersions in ThisBuild := Seq("2.11.12", "2.12.11", "2.13.2"),
-  scalaVersion in ThisBuild := "2.12.9",
+  scalaVersion in ThisBuild := "2.12.11",
   scalacOptions ++= Seq(Opts.compile.deprecation, "-Xlint", "-feature"),
   scalacOptions ++= unusedWarnings(scalaVersion.value),
   publishArtifact in Test := false,

--- a/build.sbt
+++ b/build.sbt
@@ -18,8 +18,8 @@
 val circeForScala211Version = "0.11.1" // Only for Scala v2.11
 val circeLatestVersion      = "0.12.1" // for Scala v2.12+
 val mdedetrichVersion       = "0.5.0"
-val scalacticVersion        = "3.0.8"
-val scalatestVersion        = "3.0.8"
+val scalacticVersion        = "3.1.1"
+val scalatestVersion        = "3.1.1"
 val typesafeConfigVersion   = "1.4.0"
 val typesafeLoggingVersion  = "3.9.2"
 val akkaHttpVersion         = "10.1.11"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -21,14 +21,14 @@ resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/release
 
 resolvers += "Sbt plugins" at "https://dl.bintray.com/sbt/sbt-plugin-releases"
 
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.1")
 
-addSbtPlugin("com.codacy" % "sbt-codacy-coverage" % "1.3.12")
+addSbtPlugin("com.codacy" % "sbt-codacy-coverage" % "3.0.3")
 
-addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.4")
+addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.6")
 
-addSbtPlugin("com.lucidchart" % "sbt-scalafmt" % "1.15")
+addSbtPlugin("com.lucidchart" % "sbt-scalafmt" % "1.16")
 
-addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.3.4")
+addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.5.0")
 
-addSbtPlugin("net.vonbuchholtz" % "sbt-dependency-check" % "0.2.4")
+addSbtPlugin("net.vonbuchholtz" % "sbt-dependency-check" % "2.0.0")

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1,3 +1,18 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 druid = {
 
   host = "localhost"

--- a/src/main/scala/ing/wbaa/druid/DruidQuery.scala
+++ b/src/main/scala/ing/wbaa/druid/DruidQuery.scala
@@ -17,7 +17,7 @@
 
 package ing.wbaa.druid
 
-import java.time.{ ZoneId, ZonedDateTime }
+import java.time.ZonedDateTime
 
 import akka.NotUsed
 import akka.stream.scaladsl.Source

--- a/src/main/scala/ing/wbaa/druid/SQL.scala
+++ b/src/main/scala/ing/wbaa/druid/SQL.scala
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package ing.wbaa.druid
 
 import java.sql.Timestamp

--- a/src/main/scala/ing/wbaa/druid/client/DruidAdvancedHttpClient.scala
+++ b/src/main/scala/ing/wbaa/druid/client/DruidAdvancedHttpClient.scala
@@ -92,7 +92,7 @@ class DruidAdvancedHttpClient private (
             .recover {
               case ex =>
                 healthLogger.warn(
-                  s"healthcheck of ${queryHost.host} on port ${queryHost.port} failed: $ex"
+                  s"healthcheck of ${queryHost.host} on port ${queryHost.port} failed: ${ex.toString}"
                 )
                 queryHost -> false
             }

--- a/src/main/scala/ing/wbaa/druid/client/DruidHttpClient.scala
+++ b/src/main/scala/ing/wbaa/druid/client/DruidHttpClient.scala
@@ -56,7 +56,7 @@ class DruidHttpClient private (connectionFlow: DruidHttpClient.ConnectionFlowTyp
       .recover {
         case ex =>
           healthLogger.warn(
-            s"healthcheck of ${queryHost.host} on port ${queryHost.port} failed: $ex"
+            s"healthcheck of ${queryHost.host} on port ${queryHost.port} failed: ${ex.toString}"
           )
           false
       }

--- a/src/main/scala/ing/wbaa/druid/client/HttpStatusException.scala
+++ b/src/main/scala/ing/wbaa/druid/client/HttpStatusException.scala
@@ -17,7 +17,6 @@
 package ing.wbaa.druid.client
 
 import akka.http.scaladsl.model.{ HttpEntity, HttpHeader, HttpProtocol, HttpResponse, StatusCode }
-import akka.http.scaladsl.unmarshalling.Unmarshal
 
 import scala.collection.immutable.Seq
 import scala.util.Try

--- a/src/main/scala/ing/wbaa/druid/dql/QueryBuilder.scala
+++ b/src/main/scala/ing/wbaa/druid/dql/QueryBuilder.scala
@@ -165,7 +165,7 @@ final class QueryBuilder private[dql] ()
     *
     * @return the resulting time-series query
     */
-  @deprecated(message = "use timeseries.build()")
+  @deprecated(message = "use timeseries.build()", since = "2.4.0")
   def build()(implicit druidConfig: DruidConfig = DruidConfig.DefaultConfig): TimeSeriesQuery =
     timeseries.build()
 

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -1,3 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
 <configuration>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>

--- a/src/test/scala/ing/wbaa/druid/ConfigOverridesSpec.scala
+++ b/src/test/scala/ing/wbaa/druid/ConfigOverridesSpec.scala
@@ -18,11 +18,12 @@
 package ing.wbaa.druid
 
 import ing.wbaa.druid.client.DruidAdvancedHttpClient
-import org.scalatest.{ Matchers, WordSpec }
 
 import scala.concurrent.duration._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class ConfigOverridesSpec extends WordSpec with Matchers {
+class ConfigOverridesSpec extends AnyWordSpec with Matchers {
 
   def asFiniteDuration(d: java.time.Duration): FiniteDuration =
     scala.concurrent.duration.Duration.fromNanos(d.toNanos)

--- a/src/test/scala/ing/wbaa/druid/DruidAdvancedHttpClientSpec.scala
+++ b/src/test/scala/ing/wbaa/druid/DruidAdvancedHttpClientSpec.scala
@@ -30,13 +30,16 @@ import scala.concurrent.duration._
 import scala.concurrent.{ ExecutionContextExecutor, Future }
 import scala.language.postfixOps
 import scala.util.Random
+import org.scalatest.diagrams.Diagrams
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
 class DruidAdvancedHttpClientSpec
-    extends WordSpec
+    extends AnyWordSpec
     with Matchers
     with ScalaFutures
     with Inspectors
-    with DiagrammedAssertions {
+    with Diagrams {
 
   override implicit def patienceConfig: PatienceConfig = PatienceConfig(5 minutes, 100 millis)
 

--- a/src/test/scala/ing/wbaa/druid/DruidClientSpec.scala
+++ b/src/test/scala/ing/wbaa/druid/DruidClientSpec.scala
@@ -28,8 +28,10 @@ import org.scalatest.concurrent._
 
 import scala.concurrent.duration._
 import scala.language.postfixOps
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class DruidClientSpec extends WordSpec with Matchers with ScalaFutures {
+class DruidClientSpec extends AnyWordSpec with Matchers with ScalaFutures {
 
   override implicit def patienceConfig: PatienceConfig = PatienceConfig(10 seconds, 100 millis)
 

--- a/src/test/scala/ing/wbaa/druid/DruidQuerySpec.scala
+++ b/src/test/scala/ing/wbaa/druid/DruidQuerySpec.scala
@@ -29,8 +29,10 @@ import org.scalatest.concurrent._
 import scala.concurrent.duration._
 import scala.concurrent.Future
 import scala.language.postfixOps
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class DruidQuerySpec extends WordSpec with Matchers with ScalaFutures {
+class DruidQuerySpec extends AnyWordSpec with Matchers with ScalaFutures {
 
   override implicit def patienceConfig: PatienceConfig = PatienceConfig(1 minute, 100 millis)
 

--- a/src/test/scala/ing/wbaa/druid/QueryContextSpec.scala
+++ b/src/test/scala/ing/wbaa/druid/QueryContextSpec.scala
@@ -23,8 +23,10 @@ import io.circe.syntax._
 import org.scalatest._
 import org.scalatest.concurrent._
 import org.scalatest.time._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class QueryContextSpec extends WordSpec with Matchers with ScalaFutures {
+class QueryContextSpec extends AnyWordSpec with Matchers with ScalaFutures {
 
   implicit override val patienceConfig =
     PatienceConfig(timeout = Span(20, Seconds), interval = Span(5, Millis))

--- a/src/test/scala/ing/wbaa/druid/SQLQuerySpec.scala
+++ b/src/test/scala/ing/wbaa/druid/SQLQuerySpec.scala
@@ -5,13 +5,14 @@ import java.time.{ LocalDateTime, ZonedDateTime }
 import akka.stream.scaladsl.Sink
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.time.{ Millis, Seconds, Span }
-import org.scalatest.{ Matchers, WordSpec }
 import ing.wbaa.druid.SQL._
 import ing.wbaa.druid.client.CirceDecoders
 import io.circe.generic.auto._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
 //noinspection SqlNoDataSourceInspection
-class SQLQuerySpec extends WordSpec with Matchers with ScalaFutures with CirceDecoders {
+class SQLQuerySpec extends AnyWordSpec with Matchers with ScalaFutures with CirceDecoders {
   implicit override val patienceConfig =
     PatienceConfig(timeout = Span(20, Seconds), interval = Span(5, Millis))
   private val totalNumberOfEntries  = 39244

--- a/src/test/scala/ing/wbaa/druid/SQLQuerySpec.scala
+++ b/src/test/scala/ing/wbaa/druid/SQLQuerySpec.scala
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package ing.wbaa.druid
 
 import java.time.{ LocalDateTime, ZonedDateTime }

--- a/src/test/scala/ing/wbaa/druid/auth/basic/BasicAuthenticationSpec.scala
+++ b/src/test/scala/ing/wbaa/druid/auth/basic/BasicAuthenticationSpec.scala
@@ -27,8 +27,10 @@ import org.scalatest.concurrent._
 
 import scala.concurrent.duration._
 import scala.language.postfixOps
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class BasicAuthenticationSpec extends WordSpec with Matchers with ScalaFutures {
+class BasicAuthenticationSpec extends AnyWordSpec with Matchers with ScalaFutures {
 
   override implicit def patienceConfig: PatienceConfig = PatienceConfig(5 minutes, 100 millis)
   private val totalNumberOfEntries                     = 39244

--- a/src/test/scala/ing/wbaa/druid/definitions/ExtractionFnSpec.scala
+++ b/src/test/scala/ing/wbaa/druid/definitions/ExtractionFnSpec.scala
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package ing.wbaa.druid.definitions
 
 import ing.wbaa.druid.GroupByQuery

--- a/src/test/scala/ing/wbaa/druid/definitions/ExtractionFnSpec.scala
+++ b/src/test/scala/ing/wbaa/druid/definitions/ExtractionFnSpec.scala
@@ -5,12 +5,13 @@ import ing.wbaa.druid.definitions.FilterOperators._
 import io.circe.generic.auto._
 import io.circe.syntax._
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{ Matchers, WordSpecLike }
 
 import scala.concurrent.duration._
 import scala.language.postfixOps
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
 
-class ExtractionFnSpec extends Matchers with WordSpecLike with ScalaFutures {
+class ExtractionFnSpec extends Matchers with AnyWordSpecLike with ScalaFutures {
 
   override implicit def patienceConfig: PatienceConfig = PatienceConfig(10 seconds, 100 millis)
 

--- a/src/test/scala/ing/wbaa/druid/definitions/GranularitySpec.scala
+++ b/src/test/scala/ing/wbaa/druid/definitions/GranularitySpec.scala
@@ -4,8 +4,10 @@ import org.scalatest._
 
 import io.circe._
 import io.circe.syntax._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class GranularitySpec extends WordSpec with Matchers {
+class GranularitySpec extends AnyWordSpec with Matchers {
   "Granularities" should {
     "be able to encode to json" in {
       implicit val granularityEncoder: Encoder[Granularity] = GranularityType.encoder

--- a/src/test/scala/ing/wbaa/druid/definitions/GranularitySpec.scala
+++ b/src/test/scala/ing/wbaa/druid/definitions/GranularitySpec.scala
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package ing.wbaa.druid.definitions
 
 import org.scalatest._

--- a/src/test/scala/ing/wbaa/druid/definitions/HavingSpec.scala
+++ b/src/test/scala/ing/wbaa/druid/definitions/HavingSpec.scala
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package ing.wbaa.druid.definitions
 
 import ing.wbaa.druid.GroupByQuery

--- a/src/test/scala/ing/wbaa/druid/definitions/HavingSpec.scala
+++ b/src/test/scala/ing/wbaa/druid/definitions/HavingSpec.scala
@@ -4,12 +4,13 @@ import ing.wbaa.druid.GroupByQuery
 import io.circe.generic.auto._
 import io.circe.syntax._
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{ Matchers, WordSpecLike }
 
 import scala.concurrent.duration._
 import scala.language.postfixOps
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
 
-class HavingSpec extends Matchers with WordSpecLike with ScalaFutures {
+class HavingSpec extends Matchers with AnyWordSpecLike with ScalaFutures {
 
   override implicit def patienceConfig: PatienceConfig = PatienceConfig(10 seconds, 100 millis)
 

--- a/src/test/scala/ing/wbaa/druid/definitions/PostAggregationSpec.scala
+++ b/src/test/scala/ing/wbaa/druid/definitions/PostAggregationSpec.scala
@@ -24,12 +24,13 @@ import ing.wbaa.druid.definitions.FilterOperators._
 import io.circe.generic.auto._
 import io.circe.syntax._
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{ Matchers, WordSpecLike }
 
 import scala.concurrent.duration._
 import scala.language.postfixOps
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
 
-class PostAggregationSpec extends Matchers with WordSpecLike with ScalaFutures {
+class PostAggregationSpec extends Matchers with AnyWordSpecLike with ScalaFutures {
 
   override implicit def patienceConfig: PatienceConfig = PatienceConfig(10 seconds, 100 millis)
 

--- a/src/test/scala/ing/wbaa/druid/dql/DQLSpec.scala
+++ b/src/test/scala/ing/wbaa/druid/dql/DQLSpec.scala
@@ -21,7 +21,6 @@ import akka.stream.scaladsl.Sink
 import ing.wbaa.druid.client.DruidHttpClient
 import ing.wbaa.druid._
 import ing.wbaa.druid.definitions._
-import org.scalatest.{ Matchers, WordSpec }
 import org.scalatest.concurrent._
 import ing.wbaa.druid.dql.DSL._
 import io.circe.generic.auto._
@@ -29,8 +28,10 @@ import io.circe.syntax._
 
 import scala.concurrent.duration._
 import scala.language.postfixOps
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class DQLSpec extends WordSpec with Matchers with ScalaFutures {
+class DQLSpec extends AnyWordSpec with Matchers with ScalaFutures {
 
   override implicit def patienceConfig: PatienceConfig = PatienceConfig(1 minute, 100 millis)
 


### PR DESCRIPTION
This does a bunch of prep work for the 2.4.0 release, see also ing-bank/scruid#97.

- update dependency versions
    - scalatest came with a bunch of deprecations, these have been resolved
- fix unused imports
- fix chatty logger
- add installation instructions to readme
- copy license header into source files that didn't have one