### PR TITLE
Enforce scalastyle

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -123,3 +123,11 @@ lazy val root = (project in file("."))
     libraryDependencies ++= scalaVersionSpecificDependencies(scalaVersion.value)
       .map(_ exclude ("org.scala-lang", "scala-library"))
   )
+
+lazy val compileScalastyle = taskKey[Unit]("compileScalastyle")
+compileScalastyle := (scalastyle in Compile toTask ("")).value
+(compile in Compile) := (compile in Compile dependsOn compileScalastyle).value
+
+lazy val testScalastyle = taskKey[Unit]("testScalastyle")
+testScalastyle := (scalastyle in Test toTask ("")).value
+(compile in Test) := (compile in Test dependsOn testScalastyle).value

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,3 @@
-import sbt.CrossVersion
-
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -17,8 +15,10 @@ import sbt.CrossVersion
  * limitations under the License.
  */
 
-val circeForScala211Version = "0.11.1" // Only for Scala v2.11
-val circeLatestVersion      = "0.13.0" // for Scala v2.12+
+import sbt.CrossVersion
+
+val circeVersionForScala211 = "0.11.1" // Only for Scala v2.11
+val circeVersionLatest      = "0.13.0" // for Scala v2.12+
 val mdedetrichVersion       = "0.5.0"
 val scalacticVersion        = "3.1.1"
 val scalatestVersion        = "3.1.1"
@@ -32,8 +32,8 @@ val collectionCompatVersion = "2.1.6"
 def scalaVersionSpecificDependencies(scalaVer: String): Seq[ModuleID] = {
 
   val circeScalaSpecificVersion =
-    if (scalaVer.startsWith("2.11")) circeForScala211Version
-    else circeLatestVersion
+    if (scalaVer.startsWith("2.11")) circeVersionForScala211
+    else circeVersionLatest
 
   val circeCommonArtifacts = Seq(
     "io.circe" %% "circe-core"    % circeScalaSpecificVersion,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -32,3 +32,5 @@ addSbtPlugin("com.lucidchart" % "sbt-scalafmt" % "1.16")
 addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.5.0")
 
 addSbtPlugin("net.vonbuchholtz" % "sbt-dependency-check" % "2.0.0")
+
+addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -13,9 +13,8 @@
   ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
-  -->
+-->
 <!--
-
 If you wish to turn off checking for a section of code, you can put a comment in the source
 before and after the section, with the following syntax:
 
@@ -29,12 +28,6 @@ You can also disable only one rule, by specifying its rule id, as specified in:
   // scalastyle:off no.finalize
   override def finalize(): Unit = ...
   // scalastyle:on no.finalize
-
-This file is divided into 3 sections:
- (1) rules that we enforce.
- (2) rules that we would like to enforce, but haven't cleaned up the codebase to turn on yet
-     (or we need to make the scalastyle rule more configurable).
- (3) rules that we don't want to enforce.
 -->
 
 <scalastyle>
@@ -45,6 +38,12 @@ This file is divided into 3 sections:
     <!-- ================================================================================ -->
 
     <check level="error" class="org.scalastyle.file.FileTabChecker" enabled="true"/>
+
+ <check level="error" class="org.scalastyle.file.FileLengthChecker" enabled="true">
+     <parameters>
+         <parameter name="maxFileLength"><![CDATA[800]]></parameter>
+     </parameters>
+ </check>
 
     <check level="error" class="org.scalastyle.file.HeaderMatchesChecker" enabled="true">
         <parameters>
@@ -76,20 +75,26 @@ This file is divided into 3 sections:
     <check level="error" class="org.scalastyle.file.FileLineLengthChecker" enabled="true">
         <parameters>
             <parameter name="maxLineLength"><![CDATA[120]]></parameter>
-            <parameter name="tabSize"><![CDATA[2]]></parameter>
-            <parameter name="ignoreImports">true</parameter>
+            <parameter name="tabSize"><![CDATA[4]]></parameter>
+            <parameter name="ignoreImports"><![CDATA[false]]></parameter>
         </parameters>
     </check>
 
     <check level="error" class="org.scalastyle.scalariform.ClassNamesChecker" enabled="true">
         <parameters>
-            <parameter name="regex"><![CDATA[[A-Z][A-Za-z]*]]></parameter>
+            <parameter name="regex"><![CDATA[^[A-Z][A-Za-z]*$]]></parameter>
         </parameters>
     </check>
 
     <check level="error" class="org.scalastyle.scalariform.ObjectNamesChecker" enabled="true">
         <parameters>
-            <parameter name="regex"><![CDATA[[A-Z][A-Za-z]*]]></parameter>
+            <parameter name="regex"><![CDATA[^[A-Z][A-Za-z]*$]]></parameter>
+        </parameters>
+    </check>
+
+    <check level="error" class="org.scalastyle.scalariform.PackageNamesChecker" enabled="true">
+        <parameters>
+            <parameter name="regex"><![CDATA[^[a-z][A-Za-z]*$]]></parameter>
         </parameters>
     </check>
 
@@ -116,6 +121,8 @@ This file is divided into 3 sections:
     <check level="error" class="org.scalastyle.scalariform.NoWhitespaceBeforeLeftBracketChecker" enabled="true"/>
 
     <check level="error" class="org.scalastyle.scalariform.NoWhitespaceAfterLeftBracketChecker" enabled="true"/>
+
+    <check level="error" class="org.scalastyle.scalariform.NoWhitespaceBeforeRightBracketChecker" enabled="true"/>
 
     <check level="error" class="org.scalastyle.scalariform.ReturnChecker" enabled="true"/>
 
@@ -164,28 +171,74 @@ This file is divided into 3 sections:
         </parameters>
     </check>
 
-    <check level="error" class="org.scalastyle.scalariform.NumberOfMethodsInTypeChecker" enabled="true"/>
+    <check level="error" class="org.scalastyle.scalariform.MethodArgumentNamesChecker" enabled="true">
+        <parameters>
+            <parameter name="regex"><![CDATA[^[a-z][A-Za-z0-9]*$]]></parameter>
+        </parameters>
+    </check>
+
+    <check level="error" class="org.scalastyle.scalariform.NumberOfMethodsInTypeChecker" enabled="true">
+        <parameters>
+            <parameter name="maxMethods"><![CDATA[30]]></parameter>
+        </parameters>
+    </check>
 
     <check level="error" class="org.scalastyle.scalariform.PublicMethodsHaveTypeChecker" enabled="true"/>
 
     <check level="error" class="org.scalastyle.file.NewLineAtEofChecker" enabled="true"/>
 
-    <check customId="nonascii" level="error" class="org.scalastyle.scalariform.NonASCIICharacterChecker"
-           enabled="true"/>
+    <check level="error" class="org.scalastyle.scalariform.NonASCIICharacterChecker" enabled="true"/>
+
+    <check level="error" class="org.scalastyle.scalariform.WhileChecker" enabled="true"/>
+
+    <check level="error" class="org.scalastyle.scalariform.ProcedureDeclarationChecker" enabled="true"/>
+
+    <check level="error" class="org.scalastyle.scalariform.ForBraceChecker" enabled="true"/>
+
+    <check level="error" class="org.scalastyle.scalariform.VarFieldChecker" enabled="true"/>
+
+    <check level="error" class="org.scalastyle.scalariform.VarLocalChecker" enabled="true"/>
+
+    <check level="error" class="org.scalastyle.scalariform.RedundantIfChecker" enabled="true"/>
+
+    <check level="error" class="org.scalastyle.scalariform.TokenChecker" enabled="true">
+        <parameters>
+            <parameter name="regex"><![CDATA[println]]></parameter>
+        </parameters>
+    </check>
+
+    <check level="error" class="org.scalastyle.scalariform.EmptyClassChecker" enabled="true"/>
+
+    <check level="error" class="org.scalastyle.scalariform.ClassTypeParameterChecker" enabled="true">
+        <parameters>
+            <parameter name="regex"><![CDATA[^[A-Z_]$]]></parameter>
+        </parameters>
+    </check>
 
     <check level="error" class="org.scalastyle.scalariform.SpaceAfterCommentStartChecker" enabled="true"/>
 
+    <check level="error" class="org.scalastyle.scalariform.FieldNamesChecker" enabled="true">
+        <parameters>
+            <parameter name="regex"><![CDATA[^([A-Za-z]+\d?|`type`)$]]></parameter>
+            <parameter name="objectFieldRegex"><![CDATA[^[A-Za-z]+$]]></parameter>
+        </parameters>
+    </check>
+
+    <check level="error" class="org.scalastyle.scalariform.TodoCommentChecker" enabled="true">
+        <parameters>
+            <parameter name="words"><![CDATA[TODO|FIXME]]></parameter>
+        </parameters>
+    </check>
+
     <check level="error" class="org.scalastyle.scalariform.EnsureSingleSpaceBeforeTokenChecker" enabled="true">
         <parameters>
-            <parameter name="tokens">ELSE, TRY, CATCH, FINALLY, RARROW</parameter>
+            <parameter name="tokens"><![CDATA[ELSE, TRY, CATCH, FINALLY, RARROW]]></parameter>
         </parameters>
     </check>
 
     <check level="error" class="org.scalastyle.scalariform.EnsureSingleSpaceAfterTokenChecker" enabled="true">
         <parameters>
-            <parameter name="tokens">ARROW, EQUALS, COMMA, COLON, IF, ELSE, DO, WHILE, FOR, MATCH, TRY, CATCH, FINALLY,
-                LARROW, RARROW
-            </parameter>
+            <parameter name="tokens"><![CDATA[ARROW, EQUALS, COMMA, COLON, IF, ELSE, DO, WHILE, FOR, MATCH, TRY, CATCH, FINALLY, LARROW, RARROW]]></parameter>
         </parameters>
     </check>
 
@@ -193,57 +246,42 @@ This file is divided into 3 sections:
 
     <check level="error" class="org.scalastyle.scalariform.ImportOrderChecker" enabled="true">
         <parameters>
-            <parameter name="groups">java,scala,3rdParty</parameter>
-            <parameter name="group.java">javax?\..*</parameter>
-            <parameter name="group.scala">scala\..*</parameter>
+            <parameter name="groups"><![CDATA[java,scala,other]]></parameter>
+            <parameter name="group.java"><![CDATA[javax?\..*]]></parameter>
+            <parameter name="group.scala"><![CDATA[scala\..*]]></parameter>
         </parameters>
     </check>
 
     <check level="error" class="org.scalastyle.scalariform.DisallowSpaceBeforeTokenChecker" enabled="true">
         <parameters>
-            <parameter name="tokens">COMMA</parameter>
+            <parameter name="tokens"><![CDATA[COLON, COMMA, RPAREN]]></parameter>
         </parameters>
     </check>
 
     <check customId="SingleSpaceBetweenRParenAndLCurlyBrace" level="error" class="org.scalastyle.file.RegexChecker"
            enabled="true">
         <parameters>
-            <parameter name="regex">\)\{</parameter>
+            <parameter name="regex"><![CDATA[\)\{]]></parameter>
         </parameters>
-        <customMessage><![CDATA[
-      Single Space between ')' and `{`.
-    ]]></customMessage>
+        <customMessage><![CDATA[Single Space between ')' and `{`.]]></customMessage>
     </check>
 
     <check customId="NoScalaDoc" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
         <parameters>
-            <parameter name="regex">(?m)^(\s*)/[*][*].*$(\r|)\n^\1 [*]</parameter>
+            <parameter name="regex"><![CDATA[(?m)^(\s*)/[*][*].*$(\r|)\n^\1 [*]]]></parameter>
         </parameters>
-        <customMessage>Use Javadoc style indentation for multiline comments</customMessage>
+        <customMessage><![CDATA[Use Javadoc style indentation for multiline comments]]></customMessage>
     </check>
 
     <check customId="OmitBracesInCase" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
         <parameters>
-            <parameter name="regex">case[^\n>]*=>\s*\{</parameter>
+            <parameter name="regex"><![CDATA[case[^\n>]*=>\s*\{]]></parameter>
         </parameters>
-        <customMessage>Omit braces in case clauses.</customMessage>
+        <customMessage><![CDATA[Omit braces in case clauses.]]></customMessage>
     </check>
 
     <check level="error" class="org.scalastyle.scalariform.OverrideJavaChecker" enabled="true"/>
 
     <check level="error" class="org.scalastyle.scalariform.DeprecatedJavaChecker" enabled="true"/>
-
-    <!-- ================================================================================ -->
-    <!--                               rules we don't want                                -->
-    <!-- ================================================================================ -->
-
-    <!-- We want the opposite of this: NewLineAtEofChecker -->
-    <check level="error" class="org.scalastyle.file.NoNewLineAtEofChecker" enabled="false"/>
-
-    <check level="error" class="org.scalastyle.file.FileLengthChecker" enabled="false"/>
-
-    <check level="error" class="org.scalastyle.scalariform.NumberOfTypesChecker" enabled="false"/>
-
-    <check level="error" class="org.scalastyle.scalariform.MagicNumberChecker" enabled="false"/>
 
 </scalastyle>

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -219,7 +219,7 @@ You can also disable only one rule, by specifying its rule id, as specified in:
 
     <check level="error" class="org.scalastyle.scalariform.FieldNamesChecker" enabled="true">
         <parameters>
-            <parameter name="regex"><![CDATA[^([A-Za-z]+\d?|`type`)$]]></parameter>
+            <parameter name="regex"><![CDATA[^([A-Za-z]+\d*|`type`)$]]></parameter>
             <parameter name="objectFieldRegex"><![CDATA[^[A-Za-z]+$]]></parameter>
         </parameters>
     </check>

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -181,102 +181,7 @@ This file is divided into 3 sections:
         </parameters>
     </check>
 
-    <!-- ??? usually shouldn't be checked into the code base. -->
     <check level="error" class="org.scalastyle.scalariform.NotImplementedErrorUsage" enabled="true"/>
-
-    <check customId="runtimeaddshutdownhook" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
-        <parameters>
-            <parameter name="regex">Runtime\.getRuntime\.addShutdownHook</parameter>
-        </parameters>
-        <customMessage><![CDATA[
-      Are you sure that you want to use Runtime.getRuntime.addShutdownHook? In most cases, you should use
-      ShutdownHookManager.addShutdownHook instead.
-      If you must use Runtime.getRuntime.addShutdownHook, wrap the code block with
-      // scalastyle:off runtimeaddshutdownhook
-      Runtime.getRuntime.addShutdownHook(...)
-      // scalastyle:on runtimeaddshutdownhook
-    ]]></customMessage>
-    </check>
-
-    <check customId="mutablesynchronizedbuffer" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
-        <parameters>
-            <parameter name="regex">mutable\.SynchronizedBuffer</parameter>
-        </parameters>
-        <customMessage><![CDATA[
-      Are you sure that you want to use mutable.SynchronizedBuffer? In most cases, you should use
-      java.util.concurrent.ConcurrentLinkedQueue instead.
-      If you must use mutable.SynchronizedBuffer, wrap the code block with
-      // scalastyle:off mutablesynchronizedbuffer
-      mutable.SynchronizedBuffer[...]
-      // scalastyle:on mutablesynchronizedbuffer
-    ]]></customMessage>
-    </check>
-
-    <check customId="classforname" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
-        <parameters>
-            <parameter name="regex">Class\.forName</parameter>
-        </parameters>
-        <customMessage><![CDATA[
-      Are you sure that you want to use Class.forName? In most cases, you should use Utils.classForName instead.
-      If you must use Class.forName, wrap the code block with
-      // scalastyle:off classforname
-      Class.forName(...)
-      // scalastyle:on classforname
-    ]]></customMessage>
-    </check>
-
-    <check customId="awaitresult" level="error" class="org.scalastyle.file.RegexChecker" enabled="false">
-        <parameters>
-            <parameter name="regex">Await\.result</parameter>
-        </parameters>
-        <customMessage><![CDATA[
-      Are you sure that you want to use Await.result? In most cases, you should use ThreadUtils.awaitResult instead.
-      If you must use Await.result, wrap the code block with
-      // scalastyle:off awaitresult
-      Await.result(...)
-      // scalastyle:on awaitresult
-    ]]></customMessage>
-    </check>
-
-    <check customId="awaitready" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
-        <parameters>
-            <parameter name="regex">Await\.ready</parameter>
-        </parameters>
-        <customMessage><![CDATA[
-      Are you sure that you want to use Await.ready? In most cases, you should use ThreadUtils.awaitReady instead.
-      If you must use Await.ready, wrap the code block with
-      // scalastyle:off awaitready
-      Await.ready(...)
-      // scalastyle:on awaitready
-    ]]></customMessage>
-    </check>
-
-    <check customId="javaconversions" level="error" class="org.scalastyle.scalariform.TokenChecker" enabled="true">
-        <parameters>
-            <parameter name="regex">JavaConversions</parameter>
-        </parameters>
-        <customMessage>Instead of importing implicits in scala.collection.JavaConversions._, import
-            scala.collection.JavaConverters._ and use .asScala / .asJava methods
-        </customMessage>
-    </check>
-
-    <check customId="commonslang2" level="error" class="org.scalastyle.scalariform.TokenChecker" enabled="true">
-        <parameters>
-            <parameter name="regex">org\.apache\.commons\.lang\.</parameter>
-        </parameters>
-        <customMessage>Use Commons Lang 3 classes (package org.apache.commons.lang3.*) instead
-            of Commons Lang 2 (package org.apache.commons.lang.*)
-        </customMessage>
-    </check>
-
-    <check customId="extractopt" level="error" class="org.scalastyle.scalariform.TokenChecker" enabled="true">
-        <parameters>
-            <parameter name="regex">extractOpt</parameter>
-        </parameters>
-        <customMessage>Use Utils.jsonOption(x).map(.extract[T]) instead of .extractOpt[T], as the latter
-            is slower.
-        </customMessage>
-    </check>
 
     <check level="error" class="org.scalastyle.scalariform.ImportOrderChecker" enabled="true">
         <parameters>
@@ -316,12 +221,7 @@ This file is divided into 3 sections:
         <customMessage>Omit braces in case clauses.</customMessage>
     </check>
 
-    <check customId="OverrideJavaCase" level="error" class="org.scalastyle.scalariform.TokenChecker" enabled="true">
-        <parameters>
-            <parameter name="regex">^Override$</parameter>
-        </parameters>
-        <customMessage>override modifier should be used instead of @java.lang.Override.</customMessage>
-    </check>
+    <check level="error" class="org.scalastyle.scalariform.OverrideJavaChecker" enabled="true"/>
 
     <check level="error" class="org.scalastyle.scalariform.DeprecatedJavaChecker" enabled="true"/>
 

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -38,7 +38,7 @@ This file is divided into 3 sections:
 -->
 
 <scalastyle>
-    <name>Scalastyle standard configuration</name>
+    <name>Scruid configuration</name>
 
     <!-- ================================================================================ -->
     <!--                               rules we enforce                                   -->
@@ -99,11 +99,33 @@ This file is divided into 3 sections:
         </parameters>
     </check>
 
+    <check level="error" class="org.scalastyle.scalariform.EqualsHashCodeChecker" enabled="true"/>
+
+    <check level="error" class="org.scalastyle.scalariform.IllegalImportsChecker" enabled="true">
+        <parameters>
+            <parameter name="illegalImports"><![CDATA[sun._,java.awt._]]></parameter>
+        </parameters>
+    </check>
+
     <check level="error" class="org.scalastyle.scalariform.ParameterNumberChecker" enabled="true">
         <parameters>
             <parameter name="maxParameters"><![CDATA[10]]></parameter>
         </parameters>
     </check>
+
+    <check level="error" class="org.scalastyle.scalariform.NoWhitespaceBeforeLeftBracketChecker" enabled="true"/>
+
+    <check level="error" class="org.scalastyle.scalariform.NoWhitespaceAfterLeftBracketChecker" enabled="true"/>
+
+    <check level="error" class="org.scalastyle.scalariform.ReturnChecker" enabled="true"/>
+
+    <check level="error" class="org.scalastyle.scalariform.NullChecker" enabled="true">
+        <parameters>
+            <parameter name="allowNullChecks"><![CDATA[false]]></parameter>
+        </parameters>
+    </check>
+
+    <check level="error" class="org.scalastyle.scalariform.NoCloneChecker" enabled="true"/>
 
     <check level="error" class="org.scalastyle.scalariform.NoFinalizeChecker" enabled="true"/>
 
@@ -111,12 +133,28 @@ This file is divided into 3 sections:
 
     <check level="error" class="org.scalastyle.scalariform.StructuralTypeChecker" enabled="true"/>
 
+    <check level="error" class="org.scalastyle.scalariform.CyclomaticComplexityChecker" enabled="true">
+        <parameters>
+            <parameter name="maximum"><![CDATA[10]]></parameter>
+            <parameter name="countCases"><![CDATA[false]]></parameter>
+        </parameters>
+    </check>
+
     <check level="error" class="org.scalastyle.scalariform.UppercaseLChecker" enabled="true"/>
+
+    <check level="error" class="org.scalastyle.scalariform.SimplifyBooleanExpressionChecker" enabled="true"/>
 
     <check level="error" class="org.scalastyle.scalariform.IfBraceChecker" enabled="true">
         <parameters>
             <parameter name="singleLineAllowed"><![CDATA[true]]></parameter>
             <parameter name="doubleLineAllowed"><![CDATA[true]]></parameter>
+        </parameters>
+    </check>
+
+    <check level="error" class="org.scalastyle.scalariform.MethodLengthChecker" enabled="true">
+        <parameters>
+            <parameter name="maxLength"><![CDATA[50]]></parameter>
+            <parameter name="ignoreComments"><![CDATA[true]]></parameter>
         </parameters>
     </check>
 
@@ -291,12 +329,6 @@ This file is divided into 3 sections:
     <!--       rules we'd like to enforce, but haven't cleaned up the codebase yet        -->
     <!-- ================================================================================ -->
 
-    <!-- We cannot turn the following two on, because it'd fail a lot of string interpolation use cases. -->
-    <!-- Ideally the following two rules should be configurable to rule out string interpolation. -->
-    <check level="error" class="org.scalastyle.scalariform.NoWhitespaceBeforeLeftBracketChecker"
-           enabled="false"/>
-    <check level="error" class="org.scalastyle.scalariform.NoWhitespaceAfterLeftBracketChecker" enabled="false"/>
-
     <!-- This breaks symbolic method names so we don't turn it on. -->
     <!-- Maybe we should update it to allow basic symbolic names, and then we are good to go. -->
     <check level="error" class="org.scalastyle.scalariform.MethodNamesChecker" enabled="false">
@@ -305,33 +337,12 @@ This file is divided into 3 sections:
         </parameters>
     </check>
 
-    <!-- Should turn this on, but we have a few places that need to be fixed first -->
-    <check level="error" class="org.scalastyle.scalariform.EqualsHashCodeChecker" enabled="true"/>
-
     <!-- ================================================================================ -->
     <!--                               rules we don't want                                -->
     <!-- ================================================================================ -->
 
-    <check level="error" class="org.scalastyle.scalariform.IllegalImportsChecker" enabled="false">
-        <parameters>
-            <parameter name="illegalImports"><![CDATA[sun._,java.awt._]]></parameter>
-        </parameters>
-    </check>
-
     <!-- We want the opposite of this: NewLineAtEofChecker -->
     <check level="error" class="org.scalastyle.file.NoNewLineAtEofChecker" enabled="false"/>
-
-    <!-- This one complains about all kinds of random things. Disable. -->
-    <check level="error" class="org.scalastyle.scalariform.SimplifyBooleanExpressionChecker" enabled="false"/>
-
-    <!-- We use return quite a bit for control flows and guards -->
-    <check level="error" class="org.scalastyle.scalariform.ReturnChecker" enabled="false"/>
-
-    <!-- We use null a lot in low level code and to interface with 3rd party code -->
-    <check level="error" class="org.scalastyle.scalariform.NullChecker" enabled="false"/>
-
-    <!-- Doesn't seem super big deal here ... -->
-    <check level="error" class="org.scalastyle.scalariform.NoCloneChecker" enabled="false"/>
 
     <!-- Doesn't seem super big deal here ... -->
     <check level="error" class="org.scalastyle.file.FileLengthChecker" enabled="false">
@@ -344,20 +355,6 @@ This file is divided into 3 sections:
     <check level="error" class="org.scalastyle.scalariform.NumberOfTypesChecker" enabled="false">
         <parameters>
             <parameter name="maxTypes">30</parameter>
-        </parameters>
-    </check>
-
-    <!-- Doesn't seem super big deal here ... -->
-    <check level="error" class="org.scalastyle.scalariform.CyclomaticComplexityChecker" enabled="false">
-        <parameters>
-            <parameter name="maximum">10</parameter>
-        </parameters>
-    </check>
-
-    <!-- Doesn't seem super big deal here ... -->
-    <check level="error" class="org.scalastyle.scalariform.MethodLengthChecker" enabled="false">
-        <parameters>
-            <parameter name="maxLength">50</parameter>
         </parameters>
     </check>
 

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -164,6 +164,8 @@ This file is divided into 3 sections:
         </parameters>
     </check>
 
+    <check level="error" class="org.scalastyle.scalariform.NumberOfMethodsInTypeChecker" enabled="true"/>
+
     <check level="error" class="org.scalastyle.scalariform.PublicMethodsHaveTypeChecker" enabled="true"/>
 
     <check level="error" class="org.scalastyle.file.NewLineAtEofChecker" enabled="true"/>
@@ -241,14 +243,6 @@ This file is divided into 3 sections:
     <check level="error" class="org.scalastyle.file.FileLengthChecker" enabled="false"/>
 
     <check level="error" class="org.scalastyle.scalariform.NumberOfTypesChecker" enabled="false"/>
-
-    <!-- Not exactly feasible to enforce this right now. -->
-    <!-- It is also infrequent that somebody introduces a new class with a lot of methods. -->
-    <check level="error" class="org.scalastyle.scalariform.NumberOfMethodsInTypeChecker" enabled="false">
-        <parameters>
-            <parameter name="maxMethods"><![CDATA[30]]></parameter>
-        </parameters>
-    </check>
 
     <check level="error" class="org.scalastyle.scalariform.MagicNumberChecker" enabled="false"/>
 

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -24,7 +24,7 @@ before and after the section, with the following syntax:
   // scalastyle:on
 
 You can also disable only one rule, by specifying its rule id, as specified in:
-  http://www.scalastyle.org/rules-0.7.0.html
+  http://www.scalastyle.org/rules-1.0.0.html
 
   // scalastyle:off no.finalize
   override def finalize(): Unit = ...
@@ -44,7 +44,7 @@ This file is divided into 3 sections:
     <!--                               rules we enforce                                   -->
     <!-- ================================================================================ -->
 
-    <check level="error" class="org.scalastyle.file.FileTabChecker" enabled="true"></check>
+    <check level="error" class="org.scalastyle.file.FileTabChecker" enabled="true"/>
 
     <check level="error" class="org.scalastyle.file.HeaderMatchesChecker" enabled="true">
         <parameters>
@@ -67,11 +67,11 @@ This file is divided into 3 sections:
         </parameters>
     </check>
 
-    <check level="error" class="org.scalastyle.scalariform.SpacesAfterPlusChecker" enabled="true"></check>
+    <check level="error" class="org.scalastyle.scalariform.SpacesAfterPlusChecker" enabled="true"/>
 
-    <check level="error" class="org.scalastyle.scalariform.SpacesBeforePlusChecker" enabled="true"></check>
+    <check level="error" class="org.scalastyle.scalariform.SpacesBeforePlusChecker" enabled="true"/>
 
-    <check level="error" class="org.scalastyle.file.WhitespaceEndOfLineChecker" enabled="true"></check>
+    <check level="error" class="org.scalastyle.file.WhitespaceEndOfLineChecker" enabled="true"/>
 
     <check level="error" class="org.scalastyle.file.FileLineLengthChecker" enabled="true">
         <parameters>
@@ -105,13 +105,13 @@ This file is divided into 3 sections:
         </parameters>
     </check>
 
-    <check level="error" class="org.scalastyle.scalariform.NoFinalizeChecker" enabled="true"></check>
+    <check level="error" class="org.scalastyle.scalariform.NoFinalizeChecker" enabled="true"/>
 
-    <check level="error" class="org.scalastyle.scalariform.CovariantEqualsChecker" enabled="true"></check>
+    <check level="error" class="org.scalastyle.scalariform.CovariantEqualsChecker" enabled="true"/>
 
-    <check level="error" class="org.scalastyle.scalariform.StructuralTypeChecker" enabled="true"></check>
+    <check level="error" class="org.scalastyle.scalariform.StructuralTypeChecker" enabled="true"/>
 
-    <check level="error" class="org.scalastyle.scalariform.UppercaseLChecker" enabled="true"></check>
+    <check level="error" class="org.scalastyle.scalariform.UppercaseLChecker" enabled="true"/>
 
     <check level="error" class="org.scalastyle.scalariform.IfBraceChecker" enabled="true">
         <parameters>
@@ -120,18 +120,18 @@ This file is divided into 3 sections:
         </parameters>
     </check>
 
-    <check level="error" class="org.scalastyle.scalariform.PublicMethodsHaveTypeChecker" enabled="true"></check>
+    <check level="error" class="org.scalastyle.scalariform.PublicMethodsHaveTypeChecker" enabled="true"/>
 
-    <check level="error" class="org.scalastyle.file.NewLineAtEofChecker" enabled="true"></check>
+    <check level="error" class="org.scalastyle.file.NewLineAtEofChecker" enabled="true"/>
 
     <check customId="nonascii" level="error" class="org.scalastyle.scalariform.NonASCIICharacterChecker"
-           enabled="true"></check>
+           enabled="true"/>
 
-    <check level="error" class="org.scalastyle.scalariform.SpaceAfterCommentStartChecker" enabled="true"></check>
+    <check level="error" class="org.scalastyle.scalariform.SpaceAfterCommentStartChecker" enabled="true"/>
 
     <check level="error" class="org.scalastyle.scalariform.EnsureSingleSpaceBeforeTokenChecker" enabled="true">
         <parameters>
-            <parameter name="tokens">ARROW, EQUALS, ELSE, TRY, CATCH, FINALLY, LARROW, RARROW</parameter>
+            <parameter name="tokens">ELSE, TRY, CATCH, FINALLY, RARROW</parameter>
         </parameters>
     </check>
 
@@ -144,7 +144,7 @@ This file is divided into 3 sections:
     </check>
 
     <!-- ??? usually shouldn't be checked into the code base. -->
-    <check level="error" class="org.scalastyle.scalariform.NotImplementedErrorUsage" enabled="true"></check>
+    <check level="error" class="org.scalastyle.scalariform.NotImplementedErrorUsage" enabled="true"/>
 
     <check customId="runtimeaddshutdownhook" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
         <parameters>
@@ -285,7 +285,7 @@ This file is divided into 3 sections:
         <customMessage>override modifier should be used instead of @java.lang.Override.</customMessage>
     </check>
 
-    <check level="error" class="org.scalastyle.scalariform.DeprecatedJavaChecker" enabled="true"></check>
+    <check level="error" class="org.scalastyle.scalariform.DeprecatedJavaChecker" enabled="true"/>
 
     <!-- ================================================================================ -->
     <!--       rules we'd like to enforce, but haven't cleaned up the codebase yet        -->
@@ -294,8 +294,8 @@ This file is divided into 3 sections:
     <!-- We cannot turn the following two on, because it'd fail a lot of string interpolation use cases. -->
     <!-- Ideally the following two rules should be configurable to rule out string interpolation. -->
     <check level="error" class="org.scalastyle.scalariform.NoWhitespaceBeforeLeftBracketChecker"
-           enabled="false"></check>
-    <check level="error" class="org.scalastyle.scalariform.NoWhitespaceAfterLeftBracketChecker" enabled="false"></check>
+           enabled="false"/>
+    <check level="error" class="org.scalastyle.scalariform.NoWhitespaceAfterLeftBracketChecker" enabled="false"/>
 
     <!-- This breaks symbolic method names so we don't turn it on. -->
     <!-- Maybe we should update it to allow basic symbolic names, and then we are good to go. -->
@@ -306,7 +306,7 @@ This file is divided into 3 sections:
     </check>
 
     <!-- Should turn this on, but we have a few places that need to be fixed first -->
-    <check level="error" class="org.scalastyle.scalariform.EqualsHashCodeChecker" enabled="true"></check>
+    <check level="error" class="org.scalastyle.scalariform.EqualsHashCodeChecker" enabled="true"/>
 
     <!-- ================================================================================ -->
     <!--                               rules we don't want                                -->
@@ -319,19 +319,19 @@ This file is divided into 3 sections:
     </check>
 
     <!-- We want the opposite of this: NewLineAtEofChecker -->
-    <check level="error" class="org.scalastyle.file.NoNewLineAtEofChecker" enabled="false"></check>
+    <check level="error" class="org.scalastyle.file.NoNewLineAtEofChecker" enabled="false"/>
 
     <!-- This one complains about all kinds of random things. Disable. -->
-    <check level="error" class="org.scalastyle.scalariform.SimplifyBooleanExpressionChecker" enabled="false"></check>
+    <check level="error" class="org.scalastyle.scalariform.SimplifyBooleanExpressionChecker" enabled="false"/>
 
     <!-- We use return quite a bit for control flows and guards -->
-    <check level="error" class="org.scalastyle.scalariform.ReturnChecker" enabled="false"></check>
+    <check level="error" class="org.scalastyle.scalariform.ReturnChecker" enabled="false"/>
 
     <!-- We use null a lot in low level code and to interface with 3rd party code -->
-    <check level="error" class="org.scalastyle.scalariform.NullChecker" enabled="false"></check>
+    <check level="error" class="org.scalastyle.scalariform.NullChecker" enabled="false"/>
 
     <!-- Doesn't seem super big deal here ... -->
-    <check level="error" class="org.scalastyle.scalariform.NoCloneChecker" enabled="false"></check>
+    <check level="error" class="org.scalastyle.scalariform.NoCloneChecker" enabled="false"/>
 
     <!-- Doesn't seem super big deal here ... -->
     <check level="error" class="org.scalastyle.file.FileLengthChecker" enabled="false">

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -158,6 +158,12 @@ This file is divided into 3 sections:
         </parameters>
     </check>
 
+    <check level="error" class="org.scalastyle.scalariform.MethodNamesChecker" enabled="true">
+        <parameters>
+            <parameter name="regex"><![CDATA[^([A-Z]+|[a-z][A-Za-z0-9]*|[\+\-\*/<>]|<=|>=|===|=!=|&&|\|\||unary_!)$]]></parameter>
+        </parameters>
+    </check>
+
     <check level="error" class="org.scalastyle.scalariform.PublicMethodsHaveTypeChecker" enabled="true"/>
 
     <check level="error" class="org.scalastyle.file.NewLineAtEofChecker" enabled="true"/>
@@ -226,37 +232,15 @@ This file is divided into 3 sections:
     <check level="error" class="org.scalastyle.scalariform.DeprecatedJavaChecker" enabled="true"/>
 
     <!-- ================================================================================ -->
-    <!--       rules we'd like to enforce, but haven't cleaned up the codebase yet        -->
-    <!-- ================================================================================ -->
-
-    <!-- This breaks symbolic method names so we don't turn it on. -->
-    <!-- Maybe we should update it to allow basic symbolic names, and then we are good to go. -->
-    <check level="error" class="org.scalastyle.scalariform.MethodNamesChecker" enabled="false">
-        <parameters>
-            <parameter name="regex"><![CDATA[^[a-z][A-Za-z0-9]*$]]></parameter>
-        </parameters>
-    </check>
-
-    <!-- ================================================================================ -->
     <!--                               rules we don't want                                -->
     <!-- ================================================================================ -->
 
     <!-- We want the opposite of this: NewLineAtEofChecker -->
     <check level="error" class="org.scalastyle.file.NoNewLineAtEofChecker" enabled="false"/>
 
-    <!-- Doesn't seem super big deal here ... -->
-    <check level="error" class="org.scalastyle.file.FileLengthChecker" enabled="false">
-        <parameters>
-            <parameter name="maxFileLength">800></parameter>
-        </parameters>
-    </check>
+    <check level="error" class="org.scalastyle.file.FileLengthChecker" enabled="false"/>
 
-    <!-- Doesn't seem super big deal here ... -->
-    <check level="error" class="org.scalastyle.scalariform.NumberOfTypesChecker" enabled="false">
-        <parameters>
-            <parameter name="maxTypes">30</parameter>
-        </parameters>
-    </check>
+    <check level="error" class="org.scalastyle.scalariform.NumberOfTypesChecker" enabled="false"/>
 
     <!-- Not exactly feasible to enforce this right now. -->
     <!-- It is also infrequent that somebody introduces a new class with a lot of methods. -->
@@ -266,11 +250,6 @@ This file is divided into 3 sections:
         </parameters>
     </check>
 
-    <!-- Doesn't seem super big deal here, and we have a lot of magic numbers ... -->
-    <check level="error" class="org.scalastyle.scalariform.MagicNumberChecker" enabled="false">
-        <parameters>
-            <parameter name="ignore">-1,0,1,2,3</parameter>
-        </parameters>
-    </check>
+    <check level="error" class="org.scalastyle.scalariform.MagicNumberChecker" enabled="false"/>
 
 </scalastyle>

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -249,6 +249,7 @@ You can also disable only one rule, by specifying its rule id, as specified in:
             <parameter name="groups"><![CDATA[java,scala,other]]></parameter>
             <parameter name="group.java"><![CDATA[javax?\..*]]></parameter>
             <parameter name="group.scala"><![CDATA[scala\..*]]></parameter>
+            <parameter name="group.other"><![CDATA[.*]]></parameter>
         </parameters>
     </check>
 

--- a/src/main/scala-2.11/ing/wbaa/druid/client/CirceDecoders.scala
+++ b/src/main/scala-2.11/ing/wbaa/druid/client/CirceDecoders.scala
@@ -21,7 +21,7 @@ import io.circe.java8.time._
 
 trait CirceDecoders extends JavaTimeDecoders {
 
-  protected def mapRightProjection[L, R, R1](either: Either[L,R])(f: R => R1): Either[L,R1] = either match {
+  protected def mapRightProjection[L, R, R1](either: Either[L, R])(f: R => R1): Either[L, R1] = either match {
     case Right(value) => Right(f(value))
     case _ => either.asInstanceOf[Either[L, R1]]
   }

--- a/src/main/scala-2.12/ing/wbaa/druid/client/CirceDecoders.scala
+++ b/src/main/scala-2.12/ing/wbaa/druid/client/CirceDecoders.scala
@@ -19,7 +19,7 @@ package ing.wbaa.druid.client
 
 trait CirceDecoders {
 
-  protected def mapRightProjection[L, R, R1](either: Either[L,R])(f: R => R1): Either[L,R1] = either match {
+  protected def mapRightProjection[L, R, R1](either: Either[L, R])(f: R => R1): Either[L, R1] = either match {
     case Right(value) => Right(f(value))
     case _ => either.asInstanceOf[Either[L, R1]]
   }

--- a/src/main/scala-2.13/ing/wbaa/druid/client/CirceDecoders.scala
+++ b/src/main/scala-2.13/ing/wbaa/druid/client/CirceDecoders.scala
@@ -19,6 +19,6 @@ package ing.wbaa.druid.client
 
 trait CirceDecoders {
 
-  protected def mapRightProjection[L, R, R1](either: Either[L,R])(f: R => R1): Either[L,R1] = either.map(f(_))
+  protected def mapRightProjection[L, R, R1](either: Either[L, R])(f: R => R1): Either[L, R1] = either.map(f(_))
 
 }

--- a/src/main/scala/ing/wbaa/druid/DruidConfig.scala
+++ b/src/main/scala/ing/wbaa/druid/DruidConfig.scala
@@ -21,14 +21,14 @@ import java.net.URI
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 
-import akka.actor.ActorSystem
-import com.typesafe.config.{ Config, ConfigException, ConfigFactory }
-import ing.wbaa.druid.client.{ DruidClient, DruidClientBuilder }
-
 import scala.annotation.switch
 import scala.concurrent.duration.FiniteDuration
 import scala.language.implicitConversions
 import scala.reflect.runtime.universe
+
+import akka.actor.ActorSystem
+import com.typesafe.config.{ Config, ConfigException, ConfigFactory }
+import ing.wbaa.druid.client.{ DruidClient, DruidClientBuilder }
 
 /*
  * Druid API Config Immutable

--- a/src/main/scala/ing/wbaa/druid/DruidConfig.scala
+++ b/src/main/scala/ing/wbaa/druid/DruidConfig.scala
@@ -74,10 +74,11 @@ class DruidConfig(val hosts: Seq[QueryHost],
     val obj               = runtimeMirror.reflectModule(module)
     val clientConstructor = obj.instance.asInstanceOf[DruidClientBuilder]
 
-    if (hosts.size > 1 && !clientConstructor.supportsMultipleBrokers)
+    if (hosts.size > 1 && !clientConstructor.supportsMultipleBrokers) {
       throw new IllegalStateException(
         s"The specified Druid client '${clientBackend.getName}' does not support multiple query nodes"
       )
+    }
 
     clientConstructor(this)
   }
@@ -110,6 +111,8 @@ object DruidConfig {
 
   implicit val DefaultConfig: DruidConfig = apply()
 
+  // scalastyle:off parameter.number
+  // scalastyle:off classforname
   def apply(
       hosts: Seq[QueryHost] = extractHostsFromConfig,
       secure: Boolean = druidConfig.getBoolean("secure"),
@@ -135,6 +138,8 @@ object DruidConfig {
                     scanQueryLegacyMode,
                     zoneId,
                     system)
+  // scalastyle:on classforname
+  // scalastyle:on parameter.number
 
   private def extractZoneIdFromConfig: ZoneId =
     try ZoneId.of(druidConfig.getString("zone-id"))
@@ -149,16 +154,19 @@ object DruidConfig {
     *
     * @return a sequence of query node hosts
     */
+  // scalastyle:off line.size.limit
   private def extractHostsFromConfig: Seq[QueryHost] = {
     val hosts = druidConfig.getString("hosts").trim
 
-    if (hosts.isEmpty)
+    if (hosts.isEmpty) {
       throw new ConfigException.Generic("Empty configuration parameter 'hosts'")
+    }
 
     val hostWithPortsValues = hosts.split(',').map(_.trim).toIndexedSeq
 
-    if (hostWithPortsValues.exists(_.isEmpty))
+    if (hostWithPortsValues.exists(_.isEmpty)) {
       throw new ConfigException.Generic("Empty host:port value in configuration parameter 'hosts'")
+    }
 
     hostWithPortsValues.map { hostPortStr =>
       val countSchemeSeparators = URISchemeSepPattern.findAllIn(hostPortStr).size
@@ -191,5 +199,6 @@ object DruidConfig {
       QueryHost(host, port)
     }
   }
+  // scalastyle:on line.size.limit
 
 }

--- a/src/main/scala/ing/wbaa/druid/DruidConfig.scala
+++ b/src/main/scala/ing/wbaa/druid/DruidConfig.scala
@@ -112,7 +112,6 @@ object DruidConfig {
   implicit val DefaultConfig: DruidConfig = apply()
 
   // scalastyle:off parameter.number
-  // scalastyle:off classforname
   def apply(
       hosts: Seq[QueryHost] = extractHostsFromConfig,
       secure: Boolean = druidConfig.getBoolean("secure"),
@@ -138,7 +137,6 @@ object DruidConfig {
                     scanQueryLegacyMode,
                     zoneId,
                     system)
-  // scalastyle:on classforname
   // scalastyle:on parameter.number
 
   private def extractZoneIdFromConfig: ZoneId =

--- a/src/main/scala/ing/wbaa/druid/DruidQuery.scala
+++ b/src/main/scala/ing/wbaa/druid/DruidQuery.scala
@@ -19,16 +19,16 @@ package ing.wbaa.druid
 
 import java.time.ZonedDateTime
 
+import scala.concurrent.{ ExecutionContext, Future }
+
 import akka.NotUsed
 import akka.stream.scaladsl.Source
 import ca.mrvisser.sealerate
-import ing.wbaa.druid.definitions.QueryContext.{ QueryContextParam, QueryContextValue }
 import ing.wbaa.druid.definitions._
+import ing.wbaa.druid.definitions.QueryContext.{ QueryContextParam, QueryContextValue }
+import io.circe._
 import io.circe.generic.auto._
 import io.circe.syntax._
-import io.circe._
-
-import scala.concurrent.{ ExecutionContext, Future }
 
 sealed trait QueryType extends Enum with CamelCaseEnumStringEncoder
 object QueryType extends EnumCodec[QueryType] {

--- a/src/main/scala/ing/wbaa/druid/DruidResponse.scala
+++ b/src/main/scala/ing/wbaa/druid/DruidResponse.scala
@@ -19,14 +19,14 @@ package ing.wbaa.druid
 
 import java.time._
 
+import scala.collection.immutable.ListMap
+
+// DO NOT REMOVE: required for scala 2.11
+import cats.syntax.either._
 import ing.wbaa.druid.client.CirceDecoders
 import io.circe._
-
-import scala.collection.immutable.ListMap
 import io.circe.Decoder.Result
 import io.circe.generic.semiauto.deriveDecoder
-
-import cats.syntax.either._ // DO NOT REMOVE: required for scala 2.11
 
 sealed trait DruidResponse extends CirceDecoders {
 

--- a/src/main/scala/ing/wbaa/druid/Enum.scala
+++ b/src/main/scala/ing/wbaa/druid/Enum.scala
@@ -17,9 +17,10 @@
 
 package ing.wbaa.druid
 
+// DO NOT REMOVE: required for scala 2.11
+import cats.syntax.either._
 import io.circe._
 import io.circe.syntax._
-import cats.syntax.either._ // DO NOT REMOVE: required for scala 2.11
 
 trait Enum {
   override lazy val toString: String = this.getClass.getSimpleName.split("\\$")(0)

--- a/src/main/scala/ing/wbaa/druid/Enum.scala
+++ b/src/main/scala/ing/wbaa/druid/Enum.scala
@@ -58,24 +58,24 @@ trait EnumStringEncoder { this: Enum =>
 }
 
 trait UpperCaseEnumStringEncoder extends EnumStringEncoder { this: Enum =>
-  def encode() = toString.toUpperCase
+  def encode(): String = toString.toUpperCase
 }
 
 trait LowerCaseEnumStringEncoder extends EnumStringEncoder { this: Enum =>
-  def encode() = toString.toLowerCase
+  def encode(): String = toString.toLowerCase
 }
 
 trait CamelCaseEnumStringEncoder extends EnumStringEncoder { this: Enum =>
   private def decapitalize(input: String) = s"${input.head.toLower}${input.tail}"
-  def encode()                            = decapitalize(toString)
+  def encode(): String                    = decapitalize(toString)
 }
 
 trait LispCaseEnumStringEncoder extends EnumStringEncoder { this: Enum =>
-  def encode() = DelimiterSeparatedEnumEncoder("-").encode(toString)
+  def encode(): String = DelimiterSeparatedEnumEncoder("-").encode(toString)
 }
 
 trait SnakeCaseEnumStringEncoder extends EnumStringEncoder { this: Enum =>
-  def encode() = DelimiterSeparatedEnumEncoder("_").encode(toString)
+  def encode(): String = DelimiterSeparatedEnumEncoder("_").encode(toString)
 }
 
 case class DelimiterSeparatedEnumEncoder(delimiter: String) {
@@ -83,6 +83,6 @@ case class DelimiterSeparatedEnumEncoder(delimiter: String) {
   private val PASS1       = """([A-Z]+)([A-Z][a-z])""".r
   private val PASS2       = """([a-z\d])([A-Z])""".r
   private val REPLACEMENT = "$1" + delimiter + "$2"
-  def encode(input: String) =
+  def encode(input: String): String =
     PASS2.replaceAllIn(PASS1.replaceAllIn(input, REPLACEMENT), REPLACEMENT).toLowerCase(Locale.US)
 }

--- a/src/main/scala/ing/wbaa/druid/SQL.scala
+++ b/src/main/scala/ing/wbaa/druid/SQL.scala
@@ -17,8 +17,8 @@
 
 package ing.wbaa.druid
 
-import ing.wbaa.druid.sql.SQLQueryFactory
 import ing.wbaa.druid.sql.ParameterConversions
+import ing.wbaa.druid.sql.SQLQueryFactory
 
 object SQL extends SQLQueryFactory with ParameterConversions {
 

--- a/src/main/scala/ing/wbaa/druid/SQL.scala
+++ b/src/main/scala/ing/wbaa/druid/SQL.scala
@@ -17,8 +17,7 @@
 
 package ing.wbaa.druid
 
-import ing.wbaa.druid.sql.ParameterConversions
-import ing.wbaa.druid.sql.SQLQueryFactory
+import ing.wbaa.druid.sql.{ ParameterConversions, SQLQueryFactory }
 
 object SQL extends SQLQueryFactory with ParameterConversions {
 

--- a/src/main/scala/ing/wbaa/druid/auth/basic/BasicAuthenticationExtension.scala
+++ b/src/main/scala/ing/wbaa/druid/auth/basic/BasicAuthenticationExtension.scala
@@ -16,8 +16,8 @@
  */
 package ing.wbaa.druid.auth.basic
 
-import akka.http.scaladsl.model.headers.{ Authorization, BasicHttpCredentials }
 import akka.http.scaladsl.model.HttpRequest
+import akka.http.scaladsl.model.headers.{ Authorization, BasicHttpCredentials }
 import com.typesafe.config.{ Config, ConfigFactory, ConfigValueFactory }
 import com.typesafe.scalalogging.LazyLogging
 import ing.wbaa.druid.client.{

--- a/src/main/scala/ing/wbaa/druid/client/DruidAdvancedHttpClient.scala
+++ b/src/main/scala/ing/wbaa/druid/client/DruidAdvancedHttpClient.scala
@@ -17,24 +17,24 @@
 
 package ing.wbaa.druid.client
 
+import scala.concurrent.{ ExecutionContext, ExecutionContextExecutor, Future, Promise }
+import scala.concurrent.duration._
+import scala.reflect.runtime.universe
+import scala.util.{ Failure, Success, Try }
+
 import akka.NotUsed
 import akka.actor.{ ActorSystem, Scheduler }
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.marshalling.Marshal
-import akka.http.scaladsl.model.ContentTypes._
 import akka.http.scaladsl.model._
+import akka.http.scaladsl.model.ContentTypes._
 import akka.http.scaladsl.settings.ConnectionPoolSettings
+import akka.pattern.retry
 import akka.stream._
 import akka.stream.scaladsl._
 import com.typesafe.config.{ Config, ConfigException, ConfigFactory, ConfigValueFactory }
 import ing.wbaa.druid.{ BaseResult, DruidConfig, DruidQuery, DruidResponse, QueryHost, QueryType }
-import akka.pattern.retry
 import ing.wbaa.druid.client.DruidAdvancedHttpClient.ConnectionFlow
-
-import scala.reflect.runtime.universe
-import scala.concurrent.duration._
-import scala.concurrent.{ ExecutionContext, ExecutionContextExecutor, Future, Promise }
-import scala.util.{ Failure, Success, Try }
 
 class DruidAdvancedHttpClient private (
     connectionFlow: DruidAdvancedHttpClient.ConnectionFlow,

--- a/src/main/scala/ing/wbaa/druid/client/DruidAdvancedHttpClient.scala
+++ b/src/main/scala/ing/wbaa/druid/client/DruidAdvancedHttpClient.scala
@@ -235,6 +235,7 @@ object DruidAdvancedHttpClient extends DruidClientBuilder {
     final val RequestInterceptorConfig   = "request-interceptor-config"
   }
 
+  // scalastyle:off var.field
   class ConfigBuilder {
 
     private var queueSize: Option[Int]                                = None
@@ -307,6 +308,8 @@ object DruidAdvancedHttpClient extends DruidClientBuilder {
         .withFallback(DruidConfig.DefaultConfig.clientConfig)
     }
   }
+  // scalastyle:on var.field
+
   object ConfigBuilder {
     def apply(): ConfigBuilder = new ConfigBuilder()
   }

--- a/src/main/scala/ing/wbaa/druid/client/DruidClient.scala
+++ b/src/main/scala/ing/wbaa/druid/client/DruidClient.scala
@@ -17,6 +17,10 @@
 
 package ing.wbaa.druid.client
 
+import scala.concurrent.{ ExecutionContextExecutor, Future }
+import scala.concurrent.duration.FiniteDuration
+import scala.util.{ Failure, Success, Try }
+
 import akka.NotUsed
 import akka.actor.ActorSystem
 import akka.http.scaladsl.model.{ HttpEntity, HttpResponse, StatusCodes }
@@ -25,14 +29,10 @@ import akka.stream.scaladsl._
 import com.typesafe.scalalogging.{ LazyLogging, Logger }
 import ing.wbaa.druid._
 import io.circe.Json
-import org.mdedetrich.akka.http.support.CirceHttpSupport
 import io.circe.parser.decode
+import org.mdedetrich.akka.http.support.CirceHttpSupport
 import org.mdedetrich.akka.stream.support.CirceStreamSupport
 import org.typelevel.jawn.AsyncParser
-
-import scala.concurrent.{ ExecutionContextExecutor, Future }
-import scala.concurrent.duration.FiniteDuration
-import scala.util.{ Failure, Success, Try }
 
 trait DruidClient extends CirceHttpSupport with CirceDecoders with LazyLogging {
 

--- a/src/main/scala/ing/wbaa/druid/client/DruidHttpClient.scala
+++ b/src/main/scala/ing/wbaa/druid/client/DruidHttpClient.scala
@@ -17,17 +17,17 @@
 
 package ing.wbaa.druid.client
 
+import scala.concurrent.{ ExecutionContextExecutor, Future }
+
 import akka.NotUsed
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.marshalling.Marshal
-import akka.http.scaladsl.model.ContentTypes._
 import akka.http.scaladsl.model._
+import akka.http.scaladsl.model.ContentTypes._
 import akka.stream.ActorMaterializer
 import akka.stream.scaladsl._
 import ing.wbaa.druid._
-
-import scala.concurrent.{ ExecutionContextExecutor, Future }
 
 class DruidHttpClient private (connectionFlow: DruidHttpClient.ConnectionFlowType,
                                queryHost: QueryHost)(implicit system: ActorSystem)

--- a/src/main/scala/ing/wbaa/druid/client/HttpStatusException.scala
+++ b/src/main/scala/ing/wbaa/druid/client/HttpStatusException.scala
@@ -16,10 +16,10 @@
  */
 package ing.wbaa.druid.client
 
-import akka.http.scaladsl.model.{ HttpEntity, HttpHeader, HttpProtocol, HttpResponse, StatusCode }
-
 import scala.collection.immutable.Seq
 import scala.util.Try
+
+import akka.http.scaladsl.model.{ HttpEntity, HttpHeader, HttpProtocol, HttpResponse, StatusCode }
 
 /**
   * Indicates that Druid returned a non-OK HTTP status code.

--- a/src/main/scala/ing/wbaa/druid/client/RequestInterceptor.scala
+++ b/src/main/scala/ing/wbaa/druid/client/RequestInterceptor.scala
@@ -16,10 +16,10 @@
  */
 package ing.wbaa.druid.client
 
+import scala.concurrent._
+
 import akka.http.scaladsl.model._
 import com.typesafe.config.{ Config, ConfigFactory }
-
-import scala.concurrent._
 
 /**
   * Customization hook for altering the request flow in `DruidAdvancedHttpClient`. This is primarily intended to handle

--- a/src/main/scala/ing/wbaa/druid/definitions/Aggregation.scala
+++ b/src/main/scala/ing/wbaa/druid/definitions/Aggregation.scala
@@ -19,11 +19,10 @@ package ing.wbaa.druid
 package definitions
 
 import ca.mrvisser.sealerate
+import definitions.Filter.{ encoder => filterEncoder }
 import io.circe._
 import io.circe.generic.auto._
 import io.circe.syntax._
-
-import definitions.Filter.{ encoder => filterEncoder }
 
 sealed trait AggregationType extends Enum with CamelCaseEnumStringEncoder
 object AggregationType extends EnumCodec[AggregationType] {

--- a/src/main/scala/ing/wbaa/druid/definitions/Boundary.scala
+++ b/src/main/scala/ing/wbaa/druid/definitions/Boundary.scala
@@ -17,8 +17,8 @@
 package ing.wbaa.druid
 package definitions
 
-import io.circe._
 import ca.mrvisser.sealerate
+import io.circe._
 
 sealed trait Boundary extends Enum with CamelCaseEnumStringEncoder
 

--- a/src/main/scala/ing/wbaa/druid/definitions/Filter.scala
+++ b/src/main/scala/ing/wbaa/druid/definitions/Filter.scala
@@ -87,14 +87,14 @@ object FilterOperators {
         case (Some(filterA), Some(filterB)) => Some(operator(filterA, filterB))
         case _                              => filter orElse other
       }
-    def &&(otherFilter: Option[Filter]) = apply(FilterOperators.&&, otherFilter)
-    def ||(otherFilter: Option[Filter]) = apply(FilterOperators.||, otherFilter)
+    def &&(otherFilter: Option[Filter]): Option[Filter] = apply(FilterOperators.&&, otherFilter)
+    def ||(otherFilter: Option[Filter]): Option[Filter] = apply(FilterOperators.||, otherFilter)
   }
 
   implicit class FilterExtensions(filter: Filter) {
-    def &&(otherFilter: Filter) = FilterOperators.&&(filter, otherFilter)
-    def ||(otherFilter: Filter) = FilterOperators.||(filter, otherFilter)
-    def unary_!()               = NotFilter(field = filter)
+    def &&(otherFilter: Filter): AndFilter = FilterOperators.&&(filter, otherFilter)
+    def ||(otherFilter: Filter): OrFilter  = FilterOperators.||(filter, otherFilter)
+    def unary_!(): NotFilter               = NotFilter(field = filter)
   }
 }
 

--- a/src/main/scala/ing/wbaa/druid/definitions/Granularity.scala
+++ b/src/main/scala/ing/wbaa/druid/definitions/Granularity.scala
@@ -18,8 +18,8 @@
 package ing.wbaa.druid
 package definitions
 
-import io.circe._
 import ca.mrvisser.sealerate
+import io.circe._
 
 sealed trait Granularity extends Enum with SnakeCaseEnumStringEncoder
 

--- a/src/main/scala/ing/wbaa/druid/definitions/Granularity.scala
+++ b/src/main/scala/ing/wbaa/druid/definitions/Granularity.scala
@@ -28,7 +28,8 @@ object Granularity {
   implicit val granularityDecoder: Decoder[Granularity] = GranularityType.decoder
 }
 
-// We can't use the CompanionObject for the Enum instances due to an issue in circe (knownDirectSubclasses, https://github.com/circe/circe/issues/639)
+// We can't use the CompanionObject for the Enum instances due to an issue in circe
+// (knownDirectSubclasses, https://github.com/circe/circe/issues/639)
 // Read more here: https://github.com/circe/circe/blob/master/docs/src/main/tut/codec.md
 object GranularityType extends EnumCodec[Granularity] {
   case object All           extends Granularity

--- a/src/main/scala/ing/wbaa/druid/definitions/Order.scala
+++ b/src/main/scala/ing/wbaa/druid/definitions/Order.scala
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package ing.wbaa.druid
 package definitions
 

--- a/src/main/scala/ing/wbaa/druid/definitions/Order.scala
+++ b/src/main/scala/ing/wbaa/druid/definitions/Order.scala
@@ -17,8 +17,8 @@
 package ing.wbaa.druid
 package definitions
 
-import io.circe._
 import ca.mrvisser.sealerate
+import io.circe._
 
 sealed trait Order extends Enum with LowerCaseEnumStringEncoder
 

--- a/src/main/scala/ing/wbaa/druid/definitions/PostAggregation.scala
+++ b/src/main/scala/ing/wbaa/druid/definitions/PostAggregation.scala
@@ -195,7 +195,9 @@ object ArithmeticFunctions {
   implicit class ArithmeticFunctionsOps(pa: PostAggregation) {
     def -(other: PostAggregation): ArithmeticPostAggregation = ArithmeticFunctions.-(pa, other)
 
+    // scalastyle:off spaces.before.plus
     def +(other: PostAggregation): ArithmeticPostAggregation = ArithmeticFunctions.+(pa, other)
+    // scalastyle:on spaces.before.plus
 
     def *(other: PostAggregation): ArithmeticPostAggregation = ArithmeticFunctions.*(pa, other)
 

--- a/src/main/scala/ing/wbaa/druid/dql/DSL.scala
+++ b/src/main/scala/ing/wbaa/druid/dql/DSL.scala
@@ -17,10 +17,10 @@
 
 package ing.wbaa.druid.dql
 
+import scala.language.implicitConversions
+
 import ing.wbaa.druid.definitions.ArithmeticFunction
 import ing.wbaa.druid.dql.expressions._
-
-import scala.language.implicitConversions
 
 object DSL
     extends FilteringExpressionOps

--- a/src/main/scala/ing/wbaa/druid/dql/Dim.scala
+++ b/src/main/scala/ing/wbaa/druid/dql/Dim.scala
@@ -1,6 +1,6 @@
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreement  See the NOTICE file distributed with
+ * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
  * The ASF licenses this file to You under the Apache License, Version 2.0
  * (the "License"); you may not use this file except in compliance with
@@ -158,13 +158,13 @@ case class Dim private[dql] (name: String,
   def in(value: String, values: String*): FilteringExpression =
     new In(this, value +: values)
 
-  def in(values: Iterable[String]) =
+  def in(values: Iterable[String]): In =
     new In(this, values)
 
   def in[T: Numeric](value: T, values: T*): FilteringExpression =
     new InNumeric(this, value +: values)
 
-  def in[T: Numeric](values: Iterable[T]) =
+  def in[T: Numeric](values: Iterable[T]): InNumeric[T] =
     new InNumeric(this, values)
 
   /**

--- a/src/main/scala/ing/wbaa/druid/dql/Dim.scala
+++ b/src/main/scala/ing/wbaa/druid/dql/Dim.scala
@@ -31,6 +31,7 @@ import ing.wbaa.druid.{ DimensionOrder, DimensionOrderType, Direction, OrderByCo
   * @param outputTypeOpt The resulting output type
   * @param extractionFnOpt An extraction function to apply in this dimension
   */
+// scalastyle:off number.of.methods
 case class Dim private[dql] (name: String,
                              outputNameOpt: Option[String] = None,
                              outputTypeOpt: Option[String] = None,
@@ -685,6 +686,7 @@ case class Dim private[dql] (name: String,
   def hyperUniqueCardinality: HyperUniqueCardinalityPostAgg =
     HyperUniqueCardinalityPostAgg(this.name)
 }
+// scalastyle:on number.of.methods
 
 object Dim {
 

--- a/src/main/scala/ing/wbaa/druid/dql/Dim.scala
+++ b/src/main/scala/ing/wbaa/druid/dql/Dim.scala
@@ -17,10 +17,10 @@
 
 package ing.wbaa.druid.dql
 
+import ing.wbaa.druid.{ DimensionOrder, DimensionOrderType, Direction, OrderByColumnSpec }
 import ing.wbaa.druid.definitions._
 import ing.wbaa.druid.dql.Dim.DimType
 import ing.wbaa.druid.dql.expressions._
-import ing.wbaa.druid.{ DimensionOrder, DimensionOrderType, Direction, OrderByColumnSpec }
 
 /**
   * This class represents a single dimension in a Druid datasource, along with all operations that can be

--- a/src/main/scala/ing/wbaa/druid/dql/Dim.scala
+++ b/src/main/scala/ing/wbaa/druid/dql/Dim.scala
@@ -308,7 +308,18 @@ case class Dim private[dql] (name: String,
     * @return a bound filtering expression, with lexicographic ordering, specifying that the value of
     *         the dimension should be less than, or equal to the given number.
     */
-  def =<(value: String): Bound =
+  // scalastyle:off method.name
+  @deprecated(s"use <=", "2.4.0")
+  def =<(value: String): Bound = <=(value)
+  // scalastyle:on method.name
+
+  /**
+    * Filter based on a strict upper bound of dimension values, using lexicographic ordering.
+    *
+    * @return a bound filtering expression, with lexicographic ordering, specifying that the value of
+    *         the dimension should be less than, or equal to the given number.
+    */
+  def <=(value: String): Bound =
     Bound(dimension = name,
           lower = None,
           upper = Option(value),

--- a/src/main/scala/ing/wbaa/druid/dql/Operators.scala
+++ b/src/main/scala/ing/wbaa/druid/dql/Operators.scala
@@ -17,10 +17,10 @@
 
 package ing.wbaa.druid.dql
 
+import scala.reflect.ClassTag
+
 import ing.wbaa.druid.definitions.{ ExtractionFn, Filter }
 import ing.wbaa.druid.dql.expressions._
-
-import scala.reflect.ClassTag
 
 // scalastyle:off number.of.methods
 trait AggregationOps {

--- a/src/main/scala/ing/wbaa/druid/dql/Operators.scala
+++ b/src/main/scala/ing/wbaa/druid/dql/Operators.scala
@@ -22,6 +22,7 @@ import ing.wbaa.druid.dql.expressions._
 
 import scala.reflect.ClassTag
 
+// scalastyle:off number.of.methods
 trait AggregationOps {
 
   def longSum(dimName: String): LongSumAgg = new LongSumAgg(dimName)
@@ -153,8 +154,8 @@ trait AggregationOps {
                  fnCombine: String,
                  fnReset: String): JavascriptAgg =
     JavascriptAgg(fields.toSeq, fnAggregate, fnCombine, fnReset, Option(name))
-
 }
+// scalastyle:on number.of.methods
 
 trait FilteringExpressionOps {
 

--- a/src/main/scala/ing/wbaa/druid/dql/QueryBuilder.scala
+++ b/src/main/scala/ing/wbaa/druid/dql/QueryBuilder.scala
@@ -18,8 +18,8 @@
 package ing.wbaa.druid.dql
 
 import ing.wbaa.druid._
-import ing.wbaa.druid.definitions.QueryContext.{ QueryContextParam, QueryContextValue }
 import ing.wbaa.druid.definitions._
+import ing.wbaa.druid.definitions.QueryContext.{ QueryContextParam, QueryContextValue }
 import ing.wbaa.druid.dql.expressions._
 
 // scalastyle:off var.field

--- a/src/main/scala/ing/wbaa/druid/dql/QueryBuilder.scala
+++ b/src/main/scala/ing/wbaa/druid/dql/QueryBuilder.scala
@@ -22,6 +22,8 @@ import ing.wbaa.druid.definitions.QueryContext.{ QueryContextParam, QueryContext
 import ing.wbaa.druid.definitions._
 import ing.wbaa.druid.dql.expressions._
 
+// scalastyle:off var.field
+
 /**
   * Collection of common functions for all query builders
   */
@@ -467,3 +469,5 @@ final class SearchQueryBuilder private[dql] (query: SearchQuerySpec) extends Que
     )(conf)
   }
 }
+
+// scalastyle:on var.field

--- a/src/main/scala/ing/wbaa/druid/sql/ParameterConversions.scala
+++ b/src/main/scala/ing/wbaa/druid/sql/ParameterConversions.scala
@@ -20,8 +20,9 @@ package ing.wbaa.druid.sql
 import java.sql.Timestamp
 import java.time.{ Instant, LocalDate, LocalDateTime }
 
-import ing.wbaa.druid.{ DruidConfig, SQLQueryParameter, SQLQueryParameterType }
 import scala.language.implicitConversions
+
+import ing.wbaa.druid.{ DruidConfig, SQLQueryParameter, SQLQueryParameterType }
 
 trait ParameterConversions {
   implicit def char2Param(v: Char): SQLQueryParameter =

--- a/src/test/scala/ing/wbaa/druid/ConfigOverridesSpec.scala
+++ b/src/test/scala/ing/wbaa/druid/ConfigOverridesSpec.scala
@@ -17,9 +17,9 @@
 
 package ing.wbaa.druid
 
-import ing.wbaa.druid.client.DruidAdvancedHttpClient
-
 import scala.concurrent.duration._
+
+import ing.wbaa.druid.client.DruidAdvancedHttpClient
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 

--- a/src/test/scala/ing/wbaa/druid/DruidAdvancedHttpClientSpec.scala
+++ b/src/test/scala/ing/wbaa/druid/DruidAdvancedHttpClientSpec.scala
@@ -19,18 +19,18 @@ package ing.wbaa.druid
 
 import java.util.concurrent.TimeoutException
 
-import akka.http.scaladsl.model.headers.RawHeader
+import scala.concurrent.{ ExecutionContextExecutor, Future }
+import scala.concurrent.duration._
+import scala.language.postfixOps
+import scala.util.Random
+
 import akka.http.scaladsl.model.{ HttpProtocols, StatusCodes }
+import akka.http.scaladsl.model.headers.RawHeader
 import ing.wbaa.druid.client.{ DruidAdvancedHttpClient, HttpStatusException }
 import ing.wbaa.druid.definitions._
 import ing.wbaa.druid.util._
 import org.scalatest._
 import org.scalatest.concurrent._
-
-import scala.concurrent.duration._
-import scala.concurrent.{ ExecutionContextExecutor, Future }
-import scala.language.postfixOps
-import scala.util.Random
 import org.scalatest.diagrams.Diagrams
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec

--- a/src/test/scala/ing/wbaa/druid/DruidAdvancedHttpClientSpec.scala
+++ b/src/test/scala/ing/wbaa/druid/DruidAdvancedHttpClientSpec.scala
@@ -23,6 +23,7 @@ import akka.http.scaladsl.model.headers.RawHeader
 import akka.http.scaladsl.model.{ HttpProtocols, StatusCodes }
 import ing.wbaa.druid.client.{ DruidAdvancedHttpClient, HttpStatusException }
 import ing.wbaa.druid.definitions._
+import ing.wbaa.druid.util._
 import org.scalatest._
 import org.scalatest.concurrent._
 
@@ -252,7 +253,16 @@ class DruidAdvancedHttpClientSpec
         case exception: HttpStatusException =>
           exception.status shouldBe StatusCodes.InternalServerError
           exception.entity.isFailure shouldBe false
-          exception.entity.get.data.utf8String shouldBe "{\"error\":\"Unknown exception\",\"errorMessage\":\"Cannot construct instance of `org.apache.druid.query.spec.LegacySegmentSpec`, problem: Format requires a '/' separator: invalid interval\\n at [Source: (org.eclipse.jetty.server.HttpInputOverHTTP); line: 1, column: 186] (through reference chain: org.apache.druid.query.timeseries.TimeseriesQuery[\\\"intervals\\\"])\",\"errorClass\":\"com.fasterxml.jackson.databind.exc.ValueInstantiationException\",\"host\":null}"
+          exception.entity.get.data.utf8String shouldBe
+          """{
+              |"error":"Unknown exception",
+              |"errorMessage":"Cannot construct instance of `org.apache.druid.query.spec.LegacySegmentSpec`,
+              | problem: Format requires a '/' separator: invalid interval\n
+              | at [Source: (org.eclipse.jetty.server.HttpInputOverHTTP); line: 1, column: 186]
+              | (through reference chain: org.apache.druid.query.timeseries.TimeseriesQuery[\"intervals\"])",
+              |"errorClass":"com.fasterxml.jackson.databind.exc.ValueInstantiationException",
+              |"host":null
+              |}""".toOneLine
         case response => fail(s"expected HttpStatusException, got $response")
       }
 

--- a/src/test/scala/ing/wbaa/druid/DruidClientSpec.scala
+++ b/src/test/scala/ing/wbaa/druid/DruidClientSpec.scala
@@ -23,6 +23,7 @@ import akka.http.scaladsl.model.headers.RawHeader
 import akka.http.scaladsl.model.{ HttpProtocols, StatusCodes }
 import ing.wbaa.druid.client.{ DruidHttpClient, HttpStatusException }
 import ing.wbaa.druid.definitions.{ CountAggregation, GranularityType }
+import ing.wbaa.druid.util._
 import org.scalatest.concurrent._
 
 import scala.concurrent.duration._
@@ -143,7 +144,16 @@ class DruidClientSpec extends AnyWordSpec with Matchers with ScalaFutures {
         case exception: HttpStatusException =>
           exception.status shouldBe StatusCodes.InternalServerError
           exception.entity.isFailure shouldBe false
-          exception.entity.get.data.utf8String shouldBe "{\"error\":\"Unknown exception\",\"errorMessage\":\"Cannot construct instance of `org.apache.druid.query.spec.LegacySegmentSpec`, problem: Format requires a '/' separator: invalid interval\\n at [Source: (org.eclipse.jetty.server.HttpInputOverHTTP); line: 1, column: 186] (through reference chain: org.apache.druid.query.timeseries.TimeseriesQuery[\\\"intervals\\\"])\",\"errorClass\":\"com.fasterxml.jackson.databind.exc.ValueInstantiationException\",\"host\":null}"
+          exception.entity.get.data.utf8String shouldBe
+          """{
+              |"error":"Unknown exception",
+              |"errorMessage":"Cannot construct instance of `org.apache.druid.query.spec.LegacySegmentSpec`,
+              | problem: Format requires a '/' separator: invalid interval\n
+              | at [Source: (org.eclipse.jetty.server.HttpInputOverHTTP); line: 1, column: 186]
+              | (through reference chain: org.apache.druid.query.timeseries.TimeseriesQuery[\"intervals\"])",
+              |"errorClass":"com.fasterxml.jackson.databind.exc.ValueInstantiationException",
+              |"host":null
+              |}""".toOneLine
         case response => fail(s"expected HttpStatusException, got $response")
       }
 

--- a/src/test/scala/ing/wbaa/druid/DruidClientSpec.scala
+++ b/src/test/scala/ing/wbaa/druid/DruidClientSpec.scala
@@ -19,15 +19,15 @@ package ing.wbaa.druid
 
 import java.util.concurrent.TimeoutException
 
-import akka.http.scaladsl.model.headers.RawHeader
+import scala.concurrent.duration._
+import scala.language.postfixOps
+
 import akka.http.scaladsl.model.{ HttpProtocols, StatusCodes }
+import akka.http.scaladsl.model.headers.RawHeader
 import ing.wbaa.druid.client.{ DruidHttpClient, HttpStatusException }
 import ing.wbaa.druid.definitions.{ CountAggregation, GranularityType }
 import ing.wbaa.druid.util._
 import org.scalatest.concurrent._
-
-import scala.concurrent.duration._
-import scala.language.postfixOps
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 

--- a/src/test/scala/ing/wbaa/druid/DruidQuerySpec.scala
+++ b/src/test/scala/ing/wbaa/druid/DruidQuerySpec.scala
@@ -17,18 +17,17 @@
 
 package ing.wbaa.druid
 
+import scala.concurrent.Future
+import scala.concurrent.duration._
+import scala.language.postfixOps
+
 import akka.stream.scaladsl.Sink
 import ing.wbaa.druid.client.DruidHttpClient
+import ing.wbaa.druid.definitions._
 import ing.wbaa.druid.definitions.ArithmeticFunctions._
 import ing.wbaa.druid.definitions.FilterOperators._
-import ing.wbaa.druid.definitions._
 import io.circe.generic.auto._
-import org.scalatest._
 import org.scalatest.concurrent._
-
-import scala.concurrent.duration._
-import scala.concurrent.Future
-import scala.language.postfixOps
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 

--- a/src/test/scala/ing/wbaa/druid/QueryContextSpec.scala
+++ b/src/test/scala/ing/wbaa/druid/QueryContextSpec.scala
@@ -18,6 +18,7 @@
 package ing.wbaa.druid
 
 import ing.wbaa.druid.definitions._
+import ing.wbaa.druid.util._
 import io.circe.generic.auto._
 import io.circe.syntax._
 import org.scalatest._
@@ -57,7 +58,15 @@ class QueryContextSpec extends AnyWordSpec with Matchers with ScalaFutures {
       val requestJson = query.asJson.noSpaces
 
       requestJson shouldBe
-      """{"aggregations":[{"name":"count","type":"count"}],"intervals":["2011-06-01/2017-06-01"],"filter":null,"granularity":"hour","descending":"true","postAggregations":[],"context":{"queryId":"some_custom_id","priority":"100","useCache":"false","skipEmptyBuckets":"true"}}"""
+      """{
+          |"aggregations":[{"name":"count","type":"count"}],
+          |"intervals":["2011-06-01/2017-06-01"],
+          |"filter":null,
+          |"granularity":"hour",
+          |"descending":"true",
+          |"postAggregations":[],
+          |"context":{"queryId":"some_custom_id","priority":"100","useCache":"false","skipEmptyBuckets":"true"}
+          |}""".toOneLine
 
       val resultF = query.execute()
 

--- a/src/test/scala/ing/wbaa/druid/QueryContextSpec.scala
+++ b/src/test/scala/ing/wbaa/druid/QueryContextSpec.scala
@@ -21,10 +21,9 @@ import ing.wbaa.druid.definitions._
 import ing.wbaa.druid.util._
 import io.circe.generic.auto._
 import io.circe.syntax._
-import org.scalatest._
 import org.scalatest.concurrent._
-import org.scalatest.time._
 import org.scalatest.matchers.should.Matchers
+import org.scalatest.time._
 import org.scalatest.wordspec.AnyWordSpec
 
 class QueryContextSpec extends AnyWordSpec with Matchers with ScalaFutures {

--- a/src/test/scala/ing/wbaa/druid/SQLQuerySpec.scala
+++ b/src/test/scala/ing/wbaa/druid/SQLQuerySpec.scala
@@ -28,7 +28,6 @@ import io.circe.generic.auto._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-//noinspection SqlNoDataSourceInspection
 class SQLQuerySpec extends AnyWordSpec with Matchers with ScalaFutures with CirceDecoders {
   implicit override val patienceConfig =
     PatienceConfig(timeout = Span(20, Seconds), interval = Span(5, Millis))

--- a/src/test/scala/ing/wbaa/druid/SQLQuerySpec.scala
+++ b/src/test/scala/ing/wbaa/druid/SQLQuerySpec.scala
@@ -20,12 +20,12 @@ package ing.wbaa.druid
 import java.time.{ LocalDateTime, ZonedDateTime }
 
 import akka.stream.scaladsl.Sink
-import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.time.{ Millis, Seconds, Span }
 import ing.wbaa.druid.SQL._
 import ing.wbaa.druid.client.CirceDecoders
 import io.circe.generic.auto._
+import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.matchers.should.Matchers
+import org.scalatest.time.{ Millis, Seconds, Span }
 import org.scalatest.wordspec.AnyWordSpec
 
 class SQLQuerySpec extends AnyWordSpec with Matchers with ScalaFutures with CirceDecoders {

--- a/src/test/scala/ing/wbaa/druid/auth/basic/BasicAuthenticationSpec.scala
+++ b/src/test/scala/ing/wbaa/druid/auth/basic/BasicAuthenticationSpec.scala
@@ -17,16 +17,15 @@
 
 package ing.wbaa.druid.auth.basic
 
-import akka.http.scaladsl.model.StatusCodes
-import ing.wbaa.druid.client.{ DruidAdvancedHttpClient, HttpStatusException }
-import ing.wbaa.druid.definitions._
-import ing.wbaa.druid.{ DruidConfig, QueryHost, TimeSeriesQuery }
-import io.circe.generic.auto._
-import org.scalatest._
-import org.scalatest.concurrent._
-
 import scala.concurrent.duration._
 import scala.language.postfixOps
+
+import akka.http.scaladsl.model.StatusCodes
+import ing.wbaa.druid.{ DruidConfig, QueryHost, TimeSeriesQuery }
+import ing.wbaa.druid.client.{ DruidAdvancedHttpClient, HttpStatusException }
+import ing.wbaa.druid.definitions._
+import io.circe.generic.auto._
+import org.scalatest.concurrent._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 

--- a/src/test/scala/ing/wbaa/druid/definitions/ExtractionFnSpec.scala
+++ b/src/test/scala/ing/wbaa/druid/definitions/ExtractionFnSpec.scala
@@ -17,15 +17,15 @@
 
 package ing.wbaa.druid.definitions
 
+import scala.concurrent.duration._
+import scala.language.postfixOps
+
 import ing.wbaa.druid.GroupByQuery
 import ing.wbaa.druid.definitions.FilterOperators._
 import ing.wbaa.druid.util._
 import io.circe.generic.auto._
 import io.circe.syntax._
 import org.scalatest.concurrent.ScalaFutures
-
-import scala.concurrent.duration._
-import scala.language.postfixOps
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
 

--- a/src/test/scala/ing/wbaa/druid/definitions/GranularitySpec.scala
+++ b/src/test/scala/ing/wbaa/druid/definitions/GranularitySpec.scala
@@ -17,8 +17,6 @@
 
 package ing.wbaa.druid.definitions
 
-import org.scalatest._
-
 import io.circe._
 import io.circe.syntax._
 import org.scalatest.matchers.should.Matchers

--- a/src/test/scala/ing/wbaa/druid/definitions/HavingSpec.scala
+++ b/src/test/scala/ing/wbaa/druid/definitions/HavingSpec.scala
@@ -18,6 +18,7 @@
 package ing.wbaa.druid.definitions
 
 import ing.wbaa.druid.GroupByQuery
+import ing.wbaa.druid.util._
 import io.circe.generic.auto._
 import io.circe.syntax._
 import org.scalatest.concurrent.ScalaFutures
@@ -165,7 +166,13 @@ class HavingSpec extends Matchers with AnyWordSpecLike with ScalaFutures {
           )
         )
         having.asJson.noSpaces shouldBe
-        """{"havingSpecs":[{"aggregation":"aggr","value":123.0,"type":"greaterThan"},{"dimension":"dim","value":"value","type":"dimSelector"}],"type":"and"}"""
+        """{
+            |"havingSpecs":[
+            |{"aggregation":"aggr","value":123.0,"type":"greaterThan"},
+            |{"dimension":"dim","value":"value","type":"dimSelector"}
+            |],
+            |"type":"and"
+            |}""".toOneLine
       }
 
       "should return items after applying AND having" in new TestContext {
@@ -199,7 +206,13 @@ class HavingSpec extends Matchers with AnyWordSpecLike with ScalaFutures {
           )
         )
         having.asJson.noSpaces shouldBe
-        """{"havingSpecs":[{"aggregation":"aggr","value":123.0,"type":"greaterThan"},{"dimension":"dim","value":"value","type":"dimSelector"}],"type":"or"}"""
+        """{
+            |"havingSpecs":[
+            |{"aggregation":"aggr","value":123.0,"type":"greaterThan"},
+            |{"dimension":"dim","value":"value","type":"dimSelector"}
+            |],
+            |"type":"or"
+            |}""".toOneLine
       }
 
       "should return items after applying OR having" in new TestContext {

--- a/src/test/scala/ing/wbaa/druid/definitions/HavingSpec.scala
+++ b/src/test/scala/ing/wbaa/druid/definitions/HavingSpec.scala
@@ -17,14 +17,14 @@
 
 package ing.wbaa.druid.definitions
 
+import scala.concurrent.duration._
+import scala.language.postfixOps
+
 import ing.wbaa.druid.GroupByQuery
 import ing.wbaa.druid.util._
 import io.circe.generic.auto._
 import io.circe.syntax._
 import org.scalatest.concurrent.ScalaFutures
-
-import scala.concurrent.duration._
-import scala.language.postfixOps
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
 

--- a/src/test/scala/ing/wbaa/druid/definitions/PostAggregationSpec.scala
+++ b/src/test/scala/ing/wbaa/druid/definitions/PostAggregationSpec.scala
@@ -21,6 +21,7 @@ import ing.wbaa.druid.GroupByQuery
 import ing.wbaa.druid.definitions.ArithmeticFunction.{ DIV, MINUS, MULT, PLUS, QUOT }
 import ing.wbaa.druid.definitions.ArithmeticFunctions._
 import ing.wbaa.druid.definitions.FilterOperators._
+import ing.wbaa.druid.util._
 import io.circe.generic.auto._
 import io.circe.syntax._
 import org.scalatest.concurrent.ScalaFutures
@@ -93,7 +94,16 @@ class PostAggregationSpec extends Matchers with AnyWordSpecLike with ScalaFuture
         )
 
         pa.asJson.noSpaces shouldBe
-        """{"name":"total","fn":"+","fields":[{"fieldName":"a","name":null,"type":"fieldAccess"},{"fieldName":"b","name":null,"type":"fieldAccess"}],"ordering":null,"type":"arithmetic"}"""
+        """{
+            |"name":"total",
+            |"fn":"+",
+            |"fields":[
+            |{"fieldName":"a","name":null,"type":"fieldAccess"},
+            |{"fieldName":"b","name":null,"type":"fieldAccess"}
+            |],
+            |"ordering":null,
+            |"type":"arithmetic"
+            |}""".toOneLine
       }
 
       "return items transformed with arithmetic post-aggregation" in new TestContext {
@@ -163,7 +173,12 @@ class PostAggregationSpec extends Matchers with AnyWordSpecLike with ScalaFuture
           DoubleGreatestPostAggregation("greatest",
                                         Seq(ConstantPostAggregation(10.1),
                                             ConstantPostAggregation(10.2)))
-        pa.asJson.noSpaces shouldBe """{"name":"greatest","fields":[{"value":10.1,"name":null,"type":"constant"},{"value":10.2,"name":null,"type":"constant"}],"type":"doubleGreatest"}"""
+        pa.asJson.noSpaces shouldBe
+        """{
+            |"name":"greatest",
+            |"fields":[{"value":10.1,"name":null,"type":"constant"},{"value":10.2,"name":null,"type":"constant"}],
+            |"type":"doubleGreatest"
+            |}""".toOneLine
       }
 
       "return items transformed with doubleGreatest post-aggregation" in new TestContext {
@@ -190,7 +205,12 @@ class PostAggregationSpec extends Matchers with AnyWordSpecLike with ScalaFuture
         val pa: PostAggregation =
           LongGreatestPostAggregation("greatest",
                                       Seq(ConstantPostAggregation(10), ConstantPostAggregation(12)))
-        pa.asJson.noSpaces shouldBe """{"name":"greatest","fields":[{"value":10.0,"name":null,"type":"constant"},{"value":12.0,"name":null,"type":"constant"}],"type":"longGreatest"}"""
+        pa.asJson.noSpaces shouldBe
+        """{
+            |"name":"greatest",
+            |"fields":[{"value":10.0,"name":null,"type":"constant"},{"value":12.0,"name":null,"type":"constant"}],
+            |"type":"longGreatest"
+            |}""".toOneLine
       }
 
       "return items transformed with longGreatest post-aggregation with long values" in new TestContext {
@@ -235,7 +255,12 @@ class PostAggregationSpec extends Matchers with AnyWordSpecLike with ScalaFuture
           DoubleLeastPostAggregation("least",
                                      Seq(ConstantPostAggregation(10.1),
                                          ConstantPostAggregation(10.2)))
-        pa.asJson.noSpaces shouldBe """{"name":"least","fields":[{"value":10.1,"name":null,"type":"constant"},{"value":10.2,"name":null,"type":"constant"}],"type":"doubleLeast"}"""
+        pa.asJson.noSpaces shouldBe
+        """{
+            |"name":"least",
+            |"fields":[{"value":10.1,"name":null,"type":"constant"},{"value":10.2,"name":null,"type":"constant"}],
+            |"type":"doubleLeast"
+            |}""".toOneLine
       }
 
       "return items transformed with doubleLeast post-aggregation" in new TestContext {
@@ -262,7 +287,12 @@ class PostAggregationSpec extends Matchers with AnyWordSpecLike with ScalaFuture
         val pa: PostAggregation =
           LongLeastPostAggregation("least",
                                    Seq(ConstantPostAggregation(10), ConstantPostAggregation(12)))
-        pa.asJson.noSpaces shouldBe """{"name":"least","fields":[{"value":10.0,"name":null,"type":"constant"},{"value":12.0,"name":null,"type":"constant"}],"type":"longLeast"}"""
+        pa.asJson.noSpaces shouldBe
+        """{
+            |"name":"least",
+            |"fields":[{"value":10.0,"name":null,"type":"constant"},{"value":12.0,"name":null,"type":"constant"}],
+            |"type":"longLeast"
+            |}""".toOneLine
       }
 
       "return items transformed with longLeast post-aggregation with long values" in new TestContext {
@@ -313,7 +343,12 @@ class PostAggregationSpec extends Matchers with AnyWordSpecLike with ScalaFuture
           "function(a, b) { return a + b; }"
         )
         pa.asJson.noSpaces shouldBe
-        """{"name":"least","fieldNames":["str1","str2"],"function":"function(a, b) { return a + b; }","type":"javascript"}"""
+        """{
+            |"name":"least",
+            |"fieldNames":["str1","str2"],
+            |"function":"function(a, b) { return a + b; }",
+            |"type":"javascript"
+            |}""".toOneLine
       }
     }
   }

--- a/src/test/scala/ing/wbaa/druid/definitions/PostAggregationSpec.scala
+++ b/src/test/scala/ing/wbaa/druid/definitions/PostAggregationSpec.scala
@@ -17,6 +17,9 @@
 
 package ing.wbaa.druid.definitions
 
+import scala.concurrent.duration._
+import scala.language.postfixOps
+
 import ing.wbaa.druid.GroupByQuery
 import ing.wbaa.druid.definitions.ArithmeticFunction.{ DIV, MINUS, MULT, PLUS, QUOT }
 import ing.wbaa.druid.definitions.ArithmeticFunctions._
@@ -25,9 +28,6 @@ import ing.wbaa.druid.util._
 import io.circe.generic.auto._
 import io.circe.syntax._
 import org.scalatest.concurrent.ScalaFutures
-
-import scala.concurrent.duration._
-import scala.language.postfixOps
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
 

--- a/src/test/scala/ing/wbaa/druid/dql/DQLSpec.scala
+++ b/src/test/scala/ing/wbaa/druid/dql/DQLSpec.scala
@@ -17,18 +17,18 @@
 
 package ing.wbaa.druid.dql
 
-import akka.stream.scaladsl.Sink
-import ing.wbaa.druid.client.DruidHttpClient
-import ing.wbaa.druid._
-import ing.wbaa.druid.definitions._
-import ing.wbaa.druid.util._
-import org.scalatest.concurrent._
-import ing.wbaa.druid.dql.DSL._
-import io.circe.generic.auto._
-import io.circe.syntax._
-
 import scala.concurrent.duration._
 import scala.language.postfixOps
+
+import akka.stream.scaladsl.Sink
+import ing.wbaa.druid._
+import ing.wbaa.druid.client.DruidHttpClient
+import ing.wbaa.druid.definitions._
+import ing.wbaa.druid.dql.DSL._
+import ing.wbaa.druid.util._
+import io.circe.generic.auto._
+import io.circe.syntax._
+import org.scalatest.concurrent._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 

--- a/src/test/scala/ing/wbaa/druid/dql/DQLSpec.scala
+++ b/src/test/scala/ing/wbaa/druid/dql/DQLSpec.scala
@@ -416,8 +416,7 @@ class DQLSpec extends AnyWordSpec with Matchers with ScalaFutures {
           javascript(
             name = "value",
             fields = Seq(d"cityName", d"countryIsoCode"),
-            fnAggregate =
-              """
+            fnAggregate = """
                 |function(current, countryIsoCode, cityName) {
                 |  return ((countryIsoCode != null && cityName != null) ?
                 |    cityName.length + countryIsoCode.length + current : current);

--- a/src/test/scala/ing/wbaa/druid/dql/DQLSpec.scala
+++ b/src/test/scala/ing/wbaa/druid/dql/DQLSpec.scala
@@ -21,6 +21,7 @@ import akka.stream.scaladsl.Sink
 import ing.wbaa.druid.client.DruidHttpClient
 import ing.wbaa.druid._
 import ing.wbaa.druid.definitions._
+import ing.wbaa.druid.util._
 import org.scalatest.concurrent._
 import ing.wbaa.druid.dql.DSL._
 import io.circe.generic.auto._
@@ -42,7 +43,15 @@ class DQLSpec extends AnyWordSpec with Matchers with ScalaFutures {
   private val totalNumberOfEntries = 39244
 
   private val expectedRequestAsJson =
-    """{"aggregations":[{"name":"count","type":"count"}],"intervals":["2011-06-01/2017-06-01"],"filter":null,"granularity":"hour","descending":"true","postAggregations":[],"context":{"queryId":"some_custom_id","priority":"100","useCache":"false","skipEmptyBuckets":"true"}}"""
+    """{
+      |"aggregations":[{"name":"count","type":"count"}],
+      |"intervals":["2011-06-01/2017-06-01"],
+      |"filter":null,
+      |"granularity":"hour",
+      |"descending":"true",
+      |"postAggregations":[],
+      |"context":{"queryId":"some_custom_id","priority":"100","useCache":"false","skipEmptyBuckets":"true"}
+      |}""".toOneLine
 
   case class TimeseriesCount(count: Int)
   case class GroupByIsAnonymous(isAnonymous: String, count: Int)
@@ -324,7 +333,7 @@ class DQLSpec extends AnyWordSpec with Matchers with ScalaFutures {
       val query: TopNQuery = DQL
         .topN(d"isAnonymous", metric = "count", threshold = 5)
         .agg(count)
-        .postAgg(javascript("halfCount", Seq(d"count"), "function(count){ return count/2; }"))
+        .postAgg(javascript("halfCount", Seq(d"count"), "function(count) { return count/2; }"))
         .interval("2011-06-01/2017-06-01")
         .build()
 
@@ -410,7 +419,8 @@ class DQLSpec extends AnyWordSpec with Matchers with ScalaFutures {
             fnAggregate =
               """
                 |function(current, countryIsoCode, cityName) {
-                |  return ((countryIsoCode != null && cityName != null) ? cityName.length + countryIsoCode.length + current : current);
+                |  return ((countryIsoCode != null && cityName != null) ?
+                |    cityName.length + countryIsoCode.length + current : current);
                 |}
                 |""".stripMargin,
             fnCombine = "function(partialA, partialB) { return partialA + partialB; }",

--- a/src/test/scala/ing/wbaa/druid/util/package.scala
+++ b/src/test/scala/ing/wbaa/druid/util/package.scala
@@ -15,20 +15,9 @@
  * limitations under the License.
  */
 package ing.wbaa.druid
-package definitions
 
-import io.circe._
-import ca.mrvisser.sealerate
-
-sealed trait Boundary extends Enum with CamelCaseEnumStringEncoder
-
-object Boundary {
-  implicit val boundEncoder: Encoder[Boundary] = BoundaryType.encoder
-  implicit val boundDecoder: Decoder[Boundary] = BoundaryType.decoder
-}
-
-object BoundaryType extends EnumCodec[Boundary] {
-  case object MaxTime extends Boundary
-  case object MinTime extends Boundary
-  val values: Set[Boundary] = sealerate.values[Boundary]
+package object util {
+  implicit class MultiLineString(s: String) {
+    def toOneLine: String = s.stripMargin.replaceAll("\n", "")
+  }
 }


### PR DESCRIPTION
- trigger scalastyle sbt plugin as part of compile and test configuration
- revised and cleaned up scalastyle config
- added/enabled more rules, as specified in:
  http://www.scalastyle.org/rules-1.0.0.html
- fixed scalastyle issues or disabled specific rules on the spot
- introduced String helper function `toOneLine` to work with multiline text
- deprecated Dim.=<(value: String) 