### PR TITLE
Support filtered aggregator to be used with any filter

### DIFF
--- a/docs/dql.md
+++ b/docs/dql.md
@@ -473,8 +473,9 @@ cardinality(d"dim_name_one", d"dim_name_two", d"dim_name_three".extract(Substrin
 
 #### Filtered Aggregator
 
-`inFiltered` wraps any given aggregator, but only aggregates the values for which the given dimension the *in filter* matches
+`inFiltered` wraps any given aggregator, but only aggregates the values for which the given dimension the *in filter* matches.
 Similarly, `selectorFiltered` wraps any given aggregator and filters the values using the *selector filter*.
+On the other hand, `filtered` wraps any given aggregator and filters the values using *any given filter*.
 
 
 For example, the `inFiltered` below applies over the `longSum` aggregation, only for values
@@ -495,6 +496,14 @@ d"channel".selectorFiltered(d"count".longSum, "#en.wikipedia")
 
 // Equivalent selectorFiltered as function
 selectorFiltered(d"channel", d"count".longSum, "#en.wikipedia")
+
+```
+
+The `filtered` below applies over the `longSum` aggregation, for all values except `"#en.wikipedia"` of
+`channel` dimension:
+
+```scala
+filtered(d"channel" =!= "#en.wikipedia", d"count".longSum)
 
 ```
 

--- a/src/main/scala/ing/wbaa/druid/definitions/Aggregation.scala
+++ b/src/main/scala/ing/wbaa/druid/definitions/Aggregation.scala
@@ -203,7 +203,7 @@ object FilteredAggregation {
       (agg match {
         case x: InFilteredAggregation       => x.asJsonObject
         case x: SelectorFilteredAggregation => x.asJsonObject
-        case x: AnyFilteredAggregation => x.asJsonObject
+        case x: AnyFilteredAggregation      => x.asJsonObject
       }).add("filter", filterEncoder(agg.filter)).asJson
   }
 }

--- a/src/main/scala/ing/wbaa/druid/definitions/Aggregation.scala
+++ b/src/main/scala/ing/wbaa/druid/definitions/Aggregation.scala
@@ -203,6 +203,7 @@ object FilteredAggregation {
       (agg match {
         case x: InFilteredAggregation       => x.asJsonObject
         case x: SelectorFilteredAggregation => x.asJsonObject
+        case x: AnyFilteredAggregation => x.asJsonObject
       }).add("filter", filterEncoder(agg.filter)).asJson
   }
 }
@@ -210,6 +211,8 @@ object FilteredAggregation {
 case class InFilteredAggregation(name: String, filter: InFilter, aggregator: Aggregation)
     extends FilteredAggregation
 case class SelectorFilteredAggregation(name: String, filter: SelectFilter, aggregator: Aggregation)
+    extends FilteredAggregation
+case class AnyFilteredAggregation(name: String, filter: Filter, aggregator: Aggregation)
     extends FilteredAggregation
 
 case class JavascriptAggregation(

--- a/src/main/scala/ing/wbaa/druid/dql/Operators.scala
+++ b/src/main/scala/ing/wbaa/druid/dql/Operators.scala
@@ -128,8 +128,7 @@ trait AggregationOps {
   def selectorFiltered(dim: Dim, aggregator: AggregationExpression): SelectorFilteredAgg =
     SelectorFilteredAgg(dim.name, None, aggregator.build())
 
-  def anyFiltered(filter: FilteringExpression,
-                  aggregator: AggregationExpression): AnyFilteredAgg =
+  def filtered(filter: FilteringExpression, aggregator: AggregationExpression): AnyFilteredAgg =
     AnyFilteredAgg(filter.createFilter, aggregator.build())
 
   def count: CountAgg = new CountAgg()

--- a/src/main/scala/ing/wbaa/druid/dql/Operators.scala
+++ b/src/main/scala/ing/wbaa/druid/dql/Operators.scala
@@ -128,6 +128,10 @@ trait AggregationOps {
   def selectorFiltered(dim: Dim, aggregator: AggregationExpression): SelectorFilteredAgg =
     SelectorFilteredAgg(dim.name, None, aggregator.build())
 
+  def anyFiltered(filter: FilteringExpression,
+                  aggregator: AggregationExpression): AnyFilteredAgg =
+    AnyFilteredAgg(filter.createFilter, aggregator.build())
+
   def count: CountAgg = new CountAgg()
 
   def javascript[_ <: Dim: ClassTag](fields: Iterable[Dim],

--- a/src/main/scala/ing/wbaa/druid/dql/expressions/Aggregation.scala
+++ b/src/main/scala/ing/wbaa/druid/dql/expressions/Aggregation.scala
@@ -385,6 +385,23 @@ final case class SelectorFilteredAgg(dimension: String,
   override def getName: String = name.getOrElse(s"selector_filtered_$dimension")
 }
 
+final case class AnyFilteredAgg(filter: Filter,
+                                aggregator: Aggregation,
+                                name: Option[String] = None)
+  extends AggregationExpression {
+
+  override protected[dql] def build(): Aggregation =
+    AnyFilteredAggregation(
+      this.getName,
+      filter,
+      aggregator
+    )
+
+  override def alias(name: String): AnyFilteredAgg = copy(name = Option(name))
+
+  override def getName: String = name.getOrElse(s"any_filtered_${filter.`type`}")
+}
+
 final case class JavascriptAgg(
     fields: Seq[String],
     fnAggregate: String,

--- a/src/main/scala/ing/wbaa/druid/dql/expressions/Aggregation.scala
+++ b/src/main/scala/ing/wbaa/druid/dql/expressions/Aggregation.scala
@@ -388,7 +388,7 @@ final case class SelectorFilteredAgg(dimension: String,
 final case class AnyFilteredAgg(filter: Filter,
                                 aggregator: Aggregation,
                                 name: Option[String] = None)
-  extends AggregationExpression {
+    extends AggregationExpression {
 
   override protected[dql] def build(): Aggregation =
     AnyFilteredAggregation(


### PR DESCRIPTION
Dear maintainers,

Please accept my PR which enables the use of [filtered aggregator](https://druid.apache.org/docs/latest/querying/aggregations.html#filtered-aggregator) with any filter besides "in" and "selector".