### PR TITLE
Adds support for non-string types in query context parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ val result = Future[List[DruidSearchResult]] = response.map(_.list)
 
 Queries can be configured using Druid [query context](https://druid.apache.org/docs/latest/querying/query-context.html),
 such as `timeout`, `queryId` and `groupByStrategy`. All types of query contain the argument `context` which
-associates query parameter with they corresponding values. The parameter names can also be accessed
+associates query parameter with their corresponding values. The parameter names can also be accessed
 by `ing.wbaa.druid.definitions.QueryContext` object. Consider, for example, a timeseries query with custom `query id`
 and `priority`:
 
@@ -130,7 +130,7 @@ TimeSeriesQuery(
   intervals = List("2011-06-01/2017-06-01"),
   context = Map(
     QueryContext.QueryId -> "some_custom_id",
-    QueryContext.Priority -> "10"
+    QueryContext.Priority -> 1
   )
 )
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,8 @@
 version: "2.0"
 
+networks:
+  network_scruid: {}
+
 services:
 
   scruid_druid:
@@ -8,9 +11,11 @@ services:
     ports:
       - "8081:8081"
       - "8082:8082"
-      - "8083:8082"
-      - "8084:8082"
+      - "8183:8082"
+      - "8184:8082"
       - "8888:8888"
+    networks:
+      - network_scruid
 
   delay_response:
     image: "docker.pkg.github.com/${REPOSITORY_OWNER}/clusterf-chaos-proxy:${CHAOS_PROXY_VERSION}"
@@ -22,7 +27,9 @@ services:
     environment:
       JAVA_OPTS: "-Dserver.port=8090 -Dchaos.strategy=DELAY_RESPONSE -Dchaos.strategy.delayResponse.fixedPeriod=false -Dchaos.strategy.delayResponse.random.maxSeconds=1 -Ddestination.hostProtocolAndPort=http://scruid_druid:8082"
     ports:
-      - "8085:8090"
+      - "8185:8090"
+    networks:
+      - network_scruid
 
   always_fail_500:
     image: "docker.pkg.github.com/${REPOSITORY_OWNER}/clusterf-chaos-proxy:${CHAOS_PROXY_VERSION}"
@@ -34,7 +41,9 @@ services:
     environment:
       JAVA_OPTS: "-Dserver.port=8090 -Dchaos.strategy=INTERNAL_SERVER_ERROR -Ddestination.hostProtocolAndPort=http://scruid_druid:8082"
     ports:
-      - "8086:8090"
+      - "8186:8090"
+    networks:
+      - network_scruid
 
   slow_response:
     image: "docker.pkg.github.com/${REPOSITORY_OWNER}/openresty:${OPENRESTY_VERSION}-alpine"
@@ -44,5 +53,7 @@ services:
     links:
       - scruid_druid
     ports:
-      - "8087:8080" # Slow response
-      - "8088:8081" # Basic authentication
+      - "8187:8080" # Slow response
+      - "8188:8081" # Basic authentication
+    networks:
+      - network_scruid

--- a/docker/druid/config/common.runtime.properties
+++ b/docker/druid/config/common.runtime.properties
@@ -148,3 +148,11 @@ druid.lookup.enableLookupSyncOnStartup=false
 # Javascript
 #
 druid.javascript.enabled=true
+
+#
+# Query laning to test priorities
+#
+druid.query.scheduler.laning.strategy=hilo
+druid.query.scheduler.laning.maxLowPercent=30
+druid.query.default.context.lane=low
+druid.query.scheduler.prioritization.strategy=manual

--- a/src/main/scala-2.11/ing/wbaa/druid/sql/SQLQueryFactory.scala
+++ b/src/main/scala-2.11/ing/wbaa/druid/sql/SQLQueryFactory.scala
@@ -18,13 +18,14 @@
 package ing.wbaa.druid.sql
 
 import ing.wbaa.druid.{DruidConfig, SQLQuery, SQLQueryParameter}
+import ing.wbaa.druid.definitions.QueryContext.{QueryContextParam, QueryContextValue}
 
 trait SQLQueryFactory {
 
   protected def createSQLQuery(
     sc: StringContext,
     parameters: Seq[SQLQueryParameter],
-    context: Map[String, String],
+    context: Map[QueryContextParam, QueryContextValue],
     config: DruidConfig
   ): SQLQuery = {
     sc.checkLengths(parameters)

--- a/src/main/scala-2.12/ing/wbaa/druid/sql/SQLQueryFactory.scala
+++ b/src/main/scala-2.12/ing/wbaa/druid/sql/SQLQueryFactory.scala
@@ -18,13 +18,14 @@
 package ing.wbaa.druid.sql
 
 import ing.wbaa.druid.{DruidConfig, SQLQuery, SQLQueryParameter}
+import ing.wbaa.druid.definitions.QueryContext.{QueryContextParam, QueryContextValue}
 
 trait SQLQueryFactory {
 
   protected def createSQLQuery(
     sc: StringContext,
     parameters: Seq[SQLQueryParameter],
-    context: Map[String, String],
+    context: Map[QueryContextParam, QueryContextValue],
     config: DruidConfig
   ): SQLQuery = {
     sc.checkLengths(parameters)

--- a/src/main/scala-2.13/ing/wbaa/druid/sql/SQLQueryFactory.scala
+++ b/src/main/scala-2.13/ing/wbaa/druid/sql/SQLQueryFactory.scala
@@ -18,13 +18,14 @@
 package ing.wbaa.druid.sql
 
 import ing.wbaa.druid.{DruidConfig, SQLQuery, SQLQueryParameter}
+import ing.wbaa.druid.definitions.QueryContext.{QueryContextParam, QueryContextValue}
 
 trait SQLQueryFactory {
 
   protected def createSQLQuery(
     sc: StringContext,
     parameters: Seq[SQLQueryParameter],
-    context: Map[String, String],
+    context: Map[QueryContextParam, QueryContextValue],
     config: DruidConfig
   ): SQLQuery = {
     StringContext.checkLengths(parameters, sc.parts)

--- a/src/main/scala/ing/wbaa/druid/DruidQuery.scala
+++ b/src/main/scala/ing/wbaa/druid/DruidQuery.scala
@@ -43,7 +43,7 @@ object QueryType extends EnumCodec[QueryType] {
 
 sealed trait DruidQuery {
   val queryType: QueryType
-  val context: Map[String, String]
+  val context: Map[QueryContextParam, QueryContextValue]
 
   /**
     * Utility method that converts the query to the corresponding native Druid JSON request
@@ -329,9 +329,11 @@ object SQLQueryParameterType extends EnumCodec[SQLQueryParameterType] {
 
 case class SQLQueryParameter(`type`: SQLQueryParameterType, value: String)
 
-case class SQLQuery private[druid] (query: String,
-                                    context: Map[QueryContextParam, QueryContextValue] = Map.empty,
-                                    parameters: Seq[SQLQueryParameter] = Seq.empty)(
+case class SQLQuery private[druid] (
+    query: String,
+    context: Map[QueryContextParam, QueryContextValue] = Map.empty,
+    parameters: Seq[SQLQueryParameter] = Seq.empty
+)(
     implicit val config: DruidConfig = DruidConfig.DefaultConfig
 ) extends DruidQuery {
 

--- a/src/main/scala/ing/wbaa/druid/SQL.scala
+++ b/src/main/scala/ing/wbaa/druid/SQL.scala
@@ -17,6 +17,7 @@
 
 package ing.wbaa.druid
 
+import ing.wbaa.druid.definitions.QueryContext.{ QueryContextParam, QueryContextValue }
 import ing.wbaa.druid.sql.{ ParameterConversions, SQLQueryFactory }
 
 object SQL extends SQLQueryFactory with ParameterConversions {
@@ -24,7 +25,7 @@ object SQL extends SQLQueryFactory with ParameterConversions {
   implicit class StringToSQL(val sc: StringContext) extends AnyVal {
 
     def dsql(parameters: SQLQueryParameter*)(
-        implicit context: Map[String, String] = Map.empty,
+        implicit context: Map[QueryContextParam, QueryContextValue] = Map.empty,
         config: DruidConfig = DruidConfig.DefaultConfig
     ): SQLQuery = createSQLQuery(sc, parameters, context, config)
 

--- a/src/main/scala/ing/wbaa/druid/definitions/QueryContext.scala
+++ b/src/main/scala/ing/wbaa/druid/definitions/QueryContext.scala
@@ -17,14 +17,50 @@
 
 package ing.wbaa.druid.definitions
 
+import io.circe.{ Encoder, Json }
+
 object QueryContext {
 
   type QueryContextParam = String
-  type QueryContextValue = String
+
+  sealed trait QueryContextValue {
+    def toJson: Json
+  }
+
+  object QueryContextValue {
+    implicit val encoder: Encoder[QueryContextValue] = new Encoder[QueryContextValue] {
+      override def apply(a: QueryContextValue): Json = a.toJson
+    }
+  }
+
+  implicit class QueryContextValueString(v: String) extends QueryContextValue {
+    override def toJson: Json = Json.fromString(v)
+  }
+
+  implicit class QueryContextValueInt(v: Int) extends QueryContextValue {
+    override def toJson: Json = Json.fromInt(v)
+  }
+
+  implicit class QueryContextValueLong(v: Long) extends QueryContextValue {
+    override def toJson: Json = Json.fromLong(v)
+  }
+
+  implicit class QueryContextValueBoolean(v: Boolean) extends QueryContextValue {
+    override def toJson: Json = Json.fromBoolean(v)
+  }
+
+  implicit class QueryContextValueFloat(v: Float) extends QueryContextValue {
+    override def toJson: Json = Json.fromFloatOrNull(v)
+  }
+
+  implicit class QueryContextValueDouble(v: Double) extends QueryContextValue {
+    override def toJson: Json = Json.fromDoubleOrNull(v)
+  }
 
   // the following apply only to all queries
   final val Timeout                  = "timeout"
   final val Priority                 = "priority"
+  final val Lane                     = "lane"
   final val QueryId                  = "queryId"
   final val UseCache                 = "useCache"
   final val PopulateCache            = "populateCache"
@@ -33,14 +69,21 @@ object QueryContext {
   final val BySegment                = "bySegment"
   final val Finalize                 = "finalize"
   @deprecated("deprecated context parameter in Druid", since = "2.3.0")
-  final val ChunkPeriod                  = "chunkPeriod"
-  final val MaxScatterGatherBytes        = "maxScatterGatherBytes"
-  final val MaxQueuedBytes               = "maxQueuedBytes"
-  final val SerializeDateTimeAsLong      = "serializeDateTimeAsLong"
-  final val SerializeDateTimeAsLongInner = "serializeDateTimeAsLongInner"
+  final val ChunkPeriod                   = "chunkPeriod"
+  final val MaxScatterGatherBytes         = "maxScatterGatherBytes"
+  final val MaxQueuedBytes                = "maxQueuedBytes"
+  final val SerializeDateTimeAsLong       = "serializeDateTimeAsLong"
+  final val SerializeDateTimeAsLongInner  = "serializeDateTimeAsLongInner"
+  final val EnableParallelMerge           = "enableParallelMerge"
+  final val ParallelMergeParallelism      = "parallelMergeParallelism"
+  final val ParallelMergeInitialYieldRows = "parallelMergeInitialYieldRows"
+  final val ParallelMergeSmallBatchRows   = "parallelMergeSmallBatchRows"
+  final val UseFilterCNF                  = "useFilterCNF"
+  final val SecondaryPartitionPruning     = "secondaryPartitionPruning"
 
-  final val Vectorize  = "vectorize"
-  final val VectorSize = "vectorizeSize"
+  final val Vectorize               = "vectorize"
+  final val VectorSize              = "vectorizeSize"
+  final val VectorizeVirtualColumns = "vectorizeVirtualColumns"
 
   // the following apply only to time-series queries
   final val SkipEmptyBuckets = "skipEmptyBuckets"
@@ -62,8 +105,9 @@ object QueryContext {
   final val IntermediateCombineDegree   = "intermediateCombineDegree"
   final val NumParallelCombineThreads   = "numParallelCombineThreads"
 
-  final val SortByDimsFirst    = "sortByDimsFirst"
-  final val ForceLimitPushDown = "forceLimitPushDown"
+  final val SortByDimsFirst             = "sortByDimsFirst"
+  final val ApplyLimitPushDownToSegment = "applyLimitPushDownToSegment"
+  final val ForceLimitPushDown          = "forceLimitPushDown"
 
   // group-by V1 parameters
   final val MaxIntermediateRows = "maxIntermediateRows"

--- a/src/test/scala/ing/wbaa/druid/DruidAdvancedHttpClientSpec.scala
+++ b/src/test/scala/ing/wbaa/druid/DruidAdvancedHttpClientSpec.scala
@@ -96,7 +96,7 @@ class DruidAdvancedHttpClientSpec
 
     "indicate when Druid is not healthy" in {
       val config = DruidConfig(clientBackend = classOf[DruidAdvancedHttpClient],
-                               hosts = Seq(QueryHost("localhost", 8086)))
+                               hosts = Seq(QueryHost("localhost", 8186)))
       val client = config.client
 
       whenReady(client.isHealthy()) { result =>
@@ -112,11 +112,11 @@ class DruidAdvancedHttpClientSpec
       // When the status is true the corresponding Broker is healthy, otherwise is false
       val expectedHealthCheck = Map(
         QueryHost("localhost", 8082) -> true,
-        QueryHost("localhost", 8083) -> true,
-        QueryHost("localhost", 8084) -> true,
-        QueryHost("localhost", 8085) -> true,
+        QueryHost("localhost", 8183) -> true,
+        QueryHost("localhost", 8184) -> true,
+        QueryHost("localhost", 8185) -> true,
         // the following node always fails with Internal Server Error (HTTP code 500)
-        QueryHost("localhost", 8086) -> false
+        QueryHost("localhost", 8186) -> false
       )
 
       val config = DruidConfig(clientBackend = classOf[DruidAdvancedHttpClient],
@@ -139,7 +139,7 @@ class DruidAdvancedHttpClientSpec
     "throw HttpStatusException for non-200 status codes" in {
       implicit val config =
         DruidConfig(clientBackend = classOf[DruidAdvancedHttpClient],
-                    hosts = Seq(QueryHost("localhost", 8086))) // yields HTTP 500
+                    hosts = Seq(QueryHost("localhost", 8186))) // yields HTTP 500
 
       val responseFuture = queries.head.execute()
 
@@ -163,7 +163,7 @@ class DruidAdvancedHttpClientSpec
         DruidConfig(
           clientBackend = classOf[DruidAdvancedHttpClient],
           responseParsingTimeout = 1.seconds,
-          hosts = Seq(QueryHost("localhost", 8087))
+          hosts = Seq(QueryHost("localhost", 8187))
         )
 
       val responseFuture = queries.head.execute()
@@ -205,12 +205,12 @@ class DruidAdvancedHttpClientSpec
         hosts = Seq(
           // Healthy nodes
           QueryHost("localhost", 8082),
-          QueryHost("localhost", 8083),
-          QueryHost("localhost", 8084),
+          QueryHost("localhost", 8183),
+          QueryHost("localhost", 8184),
           // Node with random delays
-          QueryHost("localhost", 8085),
+          QueryHost("localhost", 8185),
           // Node with Internal Server Error (HTTP code 500)
-          QueryHost("localhost", 8086)
+          QueryHost("localhost", 8186)
         ),
         clientBackend = classOf[DruidAdvancedHttpClient],
         clientConfig = DruidAdvancedHttpClient.ConfigBuilder().withQueryRetries(10).build()

--- a/src/test/scala/ing/wbaa/druid/DruidClientSpec.scala
+++ b/src/test/scala/ing/wbaa/druid/DruidClientSpec.scala
@@ -48,7 +48,7 @@ class DruidClientSpec extends AnyWordSpec with Matchers with ScalaFutures {
 
     "indicate when Druid is not healthy" in {
       val config = DruidConfig(clientBackend = classOf[DruidHttpClient],
-                               hosts = Seq(QueryHost("localhost", 8087)))
+                               hosts = Seq(QueryHost("localhost", 8187)))
       val client = config.client
 
       whenReady(client.isHealthy()) { result =>
@@ -59,7 +59,7 @@ class DruidClientSpec extends AnyWordSpec with Matchers with ScalaFutures {
     "fail to load when having multiple query nodes" in {
       val config = DruidConfig(clientBackend = classOf[DruidHttpClient],
                                hosts =
-                                 Seq(QueryHost("localhost", 8082), QueryHost("localhost", 8083)))
+                                 Seq(QueryHost("localhost", 8082), QueryHost("localhost", 8183)))
 
       assertThrows[IllegalStateException] {
         config.client
@@ -68,7 +68,7 @@ class DruidClientSpec extends AnyWordSpec with Matchers with ScalaFutures {
 
     "throw HttpStatusException for non-200 status codes" in {
       val config = DruidConfig(clientBackend = classOf[DruidHttpClient],
-                               hosts = Seq(QueryHost("localhost", 8086))) // yields HTTP 500
+                               hosts = Seq(QueryHost("localhost", 8186))) // yields HTTP 500
       val client = config.client
       val responseFuture = client.doQuery(
         TimeSeriesQuery(
@@ -98,7 +98,7 @@ class DruidClientSpec extends AnyWordSpec with Matchers with ScalaFutures {
         DruidConfig(
           clientBackend = classOf[DruidHttpClient],
           responseParsingTimeout = 1.seconds,
-          hosts = Seq(QueryHost("localhost", 8087))
+          hosts = Seq(QueryHost("localhost", 8187))
         )
 
       val client = config.client

--- a/src/test/scala/ing/wbaa/druid/QueryContextSpec.scala
+++ b/src/test/scala/ing/wbaa/druid/QueryContextSpec.scala
@@ -48,9 +48,9 @@ class QueryContextSpec extends AnyWordSpec with Matchers with ScalaFutures {
         intervals = List("2011-06-01/2017-06-01"),
         context = Map(
           QueryContext.QueryId          -> "some_custom_id",
-          QueryContext.Priority         -> "100",
-          QueryContext.UseCache         -> "false",
-          QueryContext.SkipEmptyBuckets -> "true"
+          QueryContext.Priority         -> 1,
+          QueryContext.UseCache         -> false,
+          QueryContext.SkipEmptyBuckets -> true
         )
       )
 
@@ -64,7 +64,7 @@ class QueryContextSpec extends AnyWordSpec with Matchers with ScalaFutures {
           |"granularity":"hour",
           |"descending":"true",
           |"postAggregations":[],
-          |"context":{"queryId":"some_custom_id","priority":"100","useCache":"false","skipEmptyBuckets":"true"}
+          |"context":{"queryId":"some_custom_id","priority":1,"useCache":false,"skipEmptyBuckets":true}
           |}""".toOneLine
 
       val resultF = query.execute()

--- a/src/test/scala/ing/wbaa/druid/auth/basic/BasicAuthenticationSpec.scala
+++ b/src/test/scala/ing/wbaa/druid/auth/basic/BasicAuthenticationSpec.scala
@@ -45,7 +45,7 @@ class BasicAuthenticationSpec extends AnyWordSpec with Matchers with ScalaFuture
       clientConfig = DruidAdvancedHttpClient
         .ConfigBuilder()
         .build(),
-      hosts = Seq(QueryHost("localhost", 8088))
+      hosts = Seq(QueryHost("localhost", 8188))
     )
 
     "get 401 Auth Required when querying Druid without Authentication config" in {
@@ -72,7 +72,7 @@ class BasicAuthenticationSpec extends AnyWordSpec with Matchers with ScalaFuture
         .ConfigBuilder()
         .withRequestInterceptor(basicAuthenticationAddition)
         .build(),
-      hosts = Seq(QueryHost("localhost", 8088))
+      hosts = Seq(QueryHost("localhost", 8188))
     )
 
     "successfully query Druid when an Authentication config is set" in {

--- a/src/test/scala/ing/wbaa/druid/dql/DQLSpec.scala
+++ b/src/test/scala/ing/wbaa/druid/dql/DQLSpec.scala
@@ -50,7 +50,7 @@ class DQLSpec extends AnyWordSpec with Matchers with ScalaFutures {
       |"granularity":"hour",
       |"descending":"true",
       |"postAggregations":[],
-      |"context":{"queryId":"some_custom_id","priority":"100","useCache":"false","skipEmptyBuckets":"true"}
+      |"context":{"queryId":"some_custom_id","priority":1,"useCache":false,"skipEmptyBuckets":true}
       |}""".toOneLine
 
   case class TimeseriesCount(count: Int)
@@ -79,6 +79,7 @@ class DQLSpec extends AnyWordSpec with Matchers with ScalaFutures {
         .granularity(GranularityType.Hour)
         .interval("2011-06-01/2017-06-01")
         .agg(count as "count")
+        .setQueryContextParam(QueryContext.Priority, 1)
         .build()
 
       val request = query.execute()
@@ -364,9 +365,9 @@ class DQLSpec extends AnyWordSpec with Matchers with ScalaFutures {
         .withQueryContext(
           Map(
             QueryContext.QueryId          -> "some_custom_id",
-            QueryContext.Priority         -> "100",
-            QueryContext.UseCache         -> "false",
-            QueryContext.SkipEmptyBuckets -> "true"
+            QueryContext.Priority         -> 1,
+            QueryContext.UseCache         -> false,
+            QueryContext.SkipEmptyBuckets -> true
           )
         )
         .build()
@@ -389,9 +390,9 @@ class DQLSpec extends AnyWordSpec with Matchers with ScalaFutures {
         .agg(count as "count")
         .setDescending(true)
         .setQueryContextParam(QueryContext.QueryId, "some_custom_id")
-        .setQueryContextParam(QueryContext.Priority, "100")
-        .setQueryContextParam(QueryContext.UseCache, "false")
-        .setQueryContextParam(QueryContext.SkipEmptyBuckets, "true")
+        .setQueryContextParam(QueryContext.Priority, 1)
+        .setQueryContextParam(QueryContext.UseCache, false)
+        .setQueryContextParam(QueryContext.SkipEmptyBuckets, true)
         .build()
 
       val requestJson = query.asJson.noSpaces


### PR DESCRIPTION
Adds support for non-string types in query context parameters

      - Adds missing constants to Query Context Parameters
      - Uses implicit value classes along with a circe encoder to support numbers and boolean in context parameters
      - Changes common.runtime.properties to enable query laning, in order to test the integer context parameter 'priority'
      - Updates unit tests
      - Updates documentation
      - docker-compose exposed ports changes to fix CI issues

GH-111